### PR TITLE
Add wins up[grade]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/rancher/wins/cmd/client"
 	"github.com/rancher/wins/cmd/server"
+	"github.com/rancher/wins/cmd/upgrade"
 	"github.com/rancher/wins/pkg/defaults"
 	"github.com/rancher/wins/pkg/panics"
 	"github.com/sirupsen/logrus"
@@ -53,6 +54,9 @@ func main() {
 
 		// cli
 		client.NewCommand(),
+
+		// upgrade
+		upgrade.NewCommand(),
 	}
 
 	if err := app.Run(os.Args); err != nil && err != io.EOF {

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -1,0 +1,19 @@
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/rancher/wins/pkg/defaults"
+	"github.com/urfave/cli"
+)
+
+func NewCommand() cli.Command {
+	return cli.Command{
+		Name:    "up",
+		Aliases: []string{"upgrade"},
+		Usage:   fmt.Sprintf("Manage %s Application", defaults.WindowsServiceDisplayName),
+		Flags:   _upgradeFlags,
+		Before:  _upgradeRequestParser,
+		Action:  _upgradeAction,
+	}
+}

--- a/cmd/upgrade/internal/powershell/powershell.go
+++ b/cmd/upgrade/internal/powershell/powershell.go
@@ -1,0 +1,63 @@
+package powershell
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Sourced from https://github.com/flannel-io/flannel/blob/d31b0dc85a5a15bda5e606acbbbb9f7089441a87/pkg/powershell/powershell.go
+
+//commandWrapper ensures that exceptions are written to stdout and the powershell process exit code is -1
+const commandWrapper = `$ErrorActionPreference="Stop";try { %s } catch { Write-Host $_; os.Exit(-1) }`
+
+// RunCommand executes a given powershell command.
+//
+// When the command throws a powershell exception, RunCommand will return the exception message as error.
+func RunCommand(command string) ([]byte, error) {
+	cmd := exec.Command("powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", fmt.Sprintf(commandWrapper, command))
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		if cmd.ProcessState.ExitCode() != 0 {
+			message := strings.TrimSpace(string(stdout))
+			return []byte{}, errors.New(message)
+		}
+
+		return []byte{}, err
+	}
+
+	return stdout, nil
+}
+
+// RunCommandf executes a given powershell command. Command argument formats according to a format specifier (See fmt.Sprintf).
+//
+// When the command throws a powershell exception, RunCommandf will return the exception message as error.
+func RunCommandf(command string, a ...interface{}) ([]byte, error) {
+	return RunCommand(fmt.Sprintf(command, a...))
+}
+
+// RunCommandWithJSONResult executes a given powershell command.
+// The command will be wrapped with ConvertTo-Json.
+//
+// You can Wrap your command with @(<cmd>) to ensure that the returned json is an array
+//
+// When the command throws a powershell exception, RunCommandf will return the exception message as error.
+func RunCommandWithJSONResult(command string, v interface{}) error {
+	wrappedCommand := fmt.Sprintf(commandWrapper, "ConvertTo-Json (%s)")
+	wrappedCommand = fmt.Sprintf(wrappedCommand, command)
+
+	stdout, err := RunCommandf(wrappedCommand)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(stdout, v)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/upgrade/internal/powershell/powershell.go
+++ b/cmd/upgrade/internal/powershell/powershell.go
@@ -54,8 +54,7 @@ func RunCommandWithJSONResult(command string, v interface{}) error {
 		return err
 	}
 
-	err = json.Unmarshal(stdout, v)
-	if err != nil {
+	if err = json.Unmarshal(stdout, v); err != nil {
 		return err
 	}
 

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -1,0 +1,130 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/wins/cmd/upgrade/internal/powershell"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+const upgradePS1Fmt = `& {
+	$ErrorActionPreference = "Stop";
+
+	$newBinPath = "%[1]s"
+	$winsArgs = "%[2]s"
+
+	$winsCmd = (Get-CimInstance Win32_Service -Filter 'Name = "rancher-wins"')
+
+	$winsSvc = Get-Service -Name rancher-wins
+	if ($winsSvc) {
+		$winsSvc | Stop-Service;
+	}
+	$winsPrc = Get-Process -Name wins -ErrorAction SilentlyContinue
+	if ($winsPrc) {
+		$winsPrc | Stop-Process -Force
+	}
+
+	if ($winsCmd -ne $null) {
+		$winsCmdPath = $winsCmd.PathName
+		$currBinPath = $winsCmdPath.Split(' ')[0]
+		if ($currBinPath -ne $newBinPath) {
+			Copy-Item -Recurse -Force -Path $newBinPath -Destination $currBinPath | Out-Null
+		}
+	} else {
+		$currBinPath = $newBinPath
+	}
+
+	Invoke-Expression "& $currBinPath srv app run --register $winsArgs"
+	Start-Service -Name rancher-wins;
+	Write-Host "Upgraded rancher-wins"
+}`
+
+const restartServicePS1 = `& {
+	$ErrorActionPreference = "Stop";
+
+	$winsCmd = (Get-CimInstance Win32_Service -Filter 'Name = "rancher-wins"')
+
+	if ($winsCmd -ne $null) {
+		$winsCmdPath = $winsCmd.PathName
+		$winsSvc = Get-Service -Name rancher-wins
+		if ($winsSvc) {
+			$winsSvc | Stop-Service;
+		}
+		$winsPrc = Get-Process -Name wins -ErrorAction SilentlyContinue
+		if ($winsPrc) {
+			$winsPrc | Stop-Process -Force
+		}
+		Invoke-Expression "& $winsCmdPath --register"
+		Start-Service -Name rancher-wins;
+		Write-Host "Restarted rancher-wins"
+	}
+}`
+
+var _upgradeFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "binary",
+		Usage: "[optional] Name of binary in working directory to upgrade to",
+		Value: os.Args[0], // default behavior is to use current binary
+	},
+	cli.StringFlag{
+		Name:  "wins-args",
+		Usage: "[optional] Arguments to pass onto wins srv app run",
+		Value: "--register",
+	},
+	cli.BoolFlag{
+		Name:  "debug",
+		Usage: "[optional] whether to print debugging logs from performing the upgrade",
+	},
+}
+
+func _upgradeRequestParser(cliCtx *cli.Context) (err error) {
+	// validate
+	binPath := cliCtx.String("binary")
+	stat, err := os.Stat(binPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Wrapf(err, "cannot find --binary %s", binPath)
+		}
+		return nil
+	} else if stat.IsDir() {
+		return errors.New("expected file for binary, found directory")
+	}
+	winsArgs := cliCtx.String("wins-args")
+	if strings.Contains(winsArgs, "--unregister") {
+		return fmt.Errorf(`cannot provide "--unregister" to --wins-args`)
+	}
+	if !strings.Contains(winsArgs, "--register") {
+		return fmt.Errorf(`must provide a string containing "--register" to --win-args`)
+	}
+	return nil
+}
+
+func _upgradeAction(cliCtx *cli.Context) (err error) {
+	if cliCtx.Bool("debug") {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	binPath := cliCtx.String("binary")
+	winsArgs := cliCtx.String("wins-args")
+	winsArgs = strings.Replace(winsArgs, "--register", "", 1)
+	out, err := powershell.RunCommandf(upgradePS1Fmt, binPath, winsArgs)
+	if len(out) > 0 {
+		logrus.Debugf("logs from upgrade.ps1 \n%s\nEOF", out)
+	}
+	if err != nil {
+		logrus.Errorf("upgrade failed, attempting to ensure rancher-wins service is not stopped: %v", err)
+		out, restartServiceErr := powershell.RunCommand(restartServicePS1)
+		if err != nil {
+			if len(out) > 0 {
+				logrus.Debugf("logs from upgrade.ps1 \n%s\nEOF", out)
+			}
+			logrus.Errorf("unable to restart rancher-wins service: %v", restartServiceErr)
+		}
+		return err
+	}
+	logrus.Info("upgrade succeeded")
+	return nil
+}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -5,11 +5,21 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/rancher/wins/cmd/upgrade/internal/powershell"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
+
+var _upgradeFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "wins-args",
+		Usage: "[optional] Arguments to pass onto wins srv app run --register",
+	},
+	cli.BoolFlag{
+		Name:  "debug",
+		Usage: "[optional] whether to print debugging logs from performing the upgrade",
+	},
+}
 
 const upgradePS1Fmt = `& {
 	$ErrorActionPreference = "Stop";
@@ -64,41 +74,14 @@ const restartServicePS1 = `& {
 	}
 }`
 
-var _upgradeFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "binary",
-		Usage: "[optional] Name of binary in working directory to upgrade to",
-		Value: os.Args[0], // default behavior is to use current binary
-	},
-	cli.StringFlag{
-		Name:  "wins-args",
-		Usage: "[optional] Arguments to pass onto wins srv app run",
-		Value: "--register",
-	},
-	cli.BoolFlag{
-		Name:  "debug",
-		Usage: "[optional] whether to print debugging logs from performing the upgrade",
-	},
-}
-
 func _upgradeRequestParser(cliCtx *cli.Context) (err error) {
 	// validate
-	binPath := cliCtx.String("binary")
-	stat, err := os.Stat(binPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "cannot find --binary %s", binPath)
-		}
-		return nil
-	} else if stat.IsDir() {
-		return errors.New("expected file for binary, found directory")
-	}
 	winsArgs := cliCtx.String("wins-args")
 	if strings.Contains(winsArgs, "--unregister") {
 		return fmt.Errorf(`cannot provide "--unregister" to --wins-args`)
 	}
 	if !strings.Contains(winsArgs, "--register") {
-		return fmt.Errorf(`must provide a string containing "--register" to --win-args`)
+		return fmt.Errorf(`cannot provide "--register" to --wins-args`)
 	}
 	return nil
 }
@@ -107,9 +90,8 @@ func _upgradeAction(cliCtx *cli.Context) (err error) {
 	if cliCtx.Bool("debug") {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	binPath := cliCtx.String("binary")
+	binPath := os.Args[0]
 	winsArgs := cliCtx.String("wins-args")
-	winsArgs = strings.Replace(winsArgs, "--register", "", 1)
 	out, err := powershell.RunCommandf(upgradePS1Fmt, binPath, winsArgs)
 	if len(out) > 0 {
 		logrus.Debugf("logs from upgrade.ps1 \n%s\nEOF", out)

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -99,9 +99,9 @@ func _upgradeAction(cliCtx *cli.Context) (err error) {
 	if err != nil {
 		logrus.Errorf("upgrade failed, attempting to ensure rancher-wins service is not stopped: %v", err)
 		out, restartServiceErr := powershell.RunCommand(restartServicePS1)
-		if err != nil {
+		if restartServiceErr != nil {
 			if len(out) > 0 {
-				logrus.Debugf("logs from upgrade.ps1 \n%s\nEOF", out)
+				logrus.Debugf("logs from restartService.ps1 \n%s\nEOF", out)
 			}
 			logrus.Errorf("unable to restart rancher-wins service: %v", restartServiceErr)
 		}


### PR DESCRIPTION
This PR adds support for running `.\wins up[grade]`, which runs a Powershell script within wins that restarts the service with a different wins server binary.

This is an alternative to the current mechanism for upgrades that wins provides wherein it watches for a path and utilizes checksums to see whether the service should be modified / restarted and can also be used as an alternative method to enable wins on a Windows host (e.g. you can just run `.\wins up` instead of `.\wins srv app run --register; Start-Service -Name rancher-wins`).

The primary use case of this feature is to support a new Helm chart that will allow users to maintain wins configs / wins versions across entire clusters using just a Helm chart for configuration. This Helm chart uses wins (cli) to pass wins (upgrade) to wins (server) in order to update wins (server) on the host on demand. More succinctly it runs:
```powershell
# Transfer the generated config to the directory
Transfer-File -Src "c:\scripts\config" -Dst "c:\host\etc\rancher\wins\config"
# Force a restart of wins server, which will naturally use the newly generated config
wins.exe cli prc run --path=$pathToWinsBinary --args="up --wins-args=`'--register --config=$pathToWinsBinaryDir\config`'"
```

More information on this can be found in https://github.com/rancher/charts/pull/996.

Only the last commit of this PR is related to changes from this PR.

Related Issue: https://github.com/rancher/wins/issues/23

Dependent on PRs:
- [x] https://github.com/rancher/wins/pull/17