### PR TITLE
Put binary in prefixPath within container

### DIFF
--- a/charts/rancher-wins-upgrader/scripts/upgrade.ps1
+++ b/charts/rancher-wins-upgrader/scripts/upgrade.ps1
@@ -36,11 +36,16 @@ function Transfer-File
     $null = Copy-Item -Force -Path $Src -Destination $Dst
 }
 
-if ($env:WINS_UPGRADE_PATH) {
-    $winsUpgradePath = $env:WINS_UPGRADE_PATH
-} else {
-    $winsUpgradePath = "C:\etc\rancher\wins\wins-upgrade.exe"
+$prefixPath = 'C:\'
+if ($env:CATTLE_PREFIX_PATH) {
+    $prefixPath = $env:CATTLE_PREFIX_PATH
 }
+$winsUpgradePath = $('{0}etc\rancher\wins\wins-upgrade.exe' -f $prefixPath)
+if ($env:WINS_UPGRADE_PATH) {
+    $winsUpgradePath = $('{0}{1}' -f $prefixPath -f $env:WINS_UPGRADE_PATH)
+}
+
+
 $winsUpgradeDir = Split-Path -Path $winsUpgradePath
 $winsUpgradeFilename = Split-Path -Path $winsUpgradePath -Leaf
 

--- a/charts/rancher-wins-upgrader/templates/daemonset.yaml
+++ b/charts/rancher-wins-upgrader/templates/daemonset.yaml
@@ -43,6 +43,8 @@ spec:
         env:
         - name: HELM_REVISION_NUMBER
           value: {{ $.Release.Revision | quote }}
+        - name: CATTLE_PREFIX_PATH
+          value: {{ default "C:\\" $.Values.global.cattle.rkeWindowsPathPrefix | replace "/" "\\" }}
 {{- if $.Values.masquerade.enabled }}
         - name: WINS_UPGRADE_PATH
           value: {{ include "winsUpgrader.winsMasqueradePath" $ }}


### PR DESCRIPTION
The reason why this change is necessary is because wins performs a checksum on the exact same path that must exist in the container and must exist on the host. Therefore, even though there is no need for the container to have knowledge of the CATTLE_PREFIX_PATH, it must for wins to be able to checksum correctly.

Related Issue: https://github.com/rancher/rancher/issues/32194