### PR TITLE
Copying the wins.exe to the location expected by monitoring chart.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -536,6 +536,14 @@ systemagent:
         }
     }
 
+    function Copy-WinsForCharts() {
+        $winsForChartsPath = "c:/windows"
+        if (-Not (Test-Path $winsForChartsPath)) {
+            New-Item $winsForChartsPath -ItemType Directory
+        }
+        Copy-Item -Path "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe" -Destination "$winsForChartsPath/wins.exe" -Force
+    }
+
     function Invoke-WinsAgentInstall() {
         $serviceName = "rancher-wins"
         Get-Args
@@ -550,6 +558,7 @@ systemagent:
         Test-RancherConnection
         Stop-Agent -ServiceName $serviceName
         Invoke-WinsAgentDownload
+        Copy-WinsForCharts
         Set-WinsConfig
 
         if ($env:CATTLE_TOKEN) {


### PR DESCRIPTION
This just copies the wins.exe as part of the instal.ps1 to guarantee that Wins in the location expected in the charts. This was handled by the Rancher-agent prior to RKE2.

* https://github.com/rancher/rancher/issues/35851

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>