### PR TITLE
switch to deleting the existing file instead of moving it to temp dir

### DIFF
--- a/pkg/paths/file.go
+++ b/pkg/paths/file.go
@@ -55,17 +55,14 @@ func MoveFile(srcPath, targetPath string) error {
 
 	// if target path is already existing
 	if _, err := os.Stat(targetPath); err == nil {
-		// don't remove binary directly
-		tempTargetPath := filepath.Join(os.TempDir(), filepath.Base(targetPath))
-		err = os.Rename(targetPath, tempTargetPath)
-		if err != nil {
-			return errors.Wrap(err, "could not backup the existing target file")
+		// it already exists so delete it so we can move the new one in
+		if err = os.Remove(targetPath); err != nil {
+			return errors.Wrapf(err, "could not remove existing target file %s", targetPath)
 		}
 	}
 
-	err = os.Rename(srcPath, targetPath)
-	if err != nil {
-		return errors.Wrap(err, "could not move the source file to the target")
+	if err = os.Rename(srcPath, targetPath); err != nil {
+		return errors.Wrapf(err, "could not move the source file to the target %s", targetPath)
 	}
 
 	return nil


### PR DESCRIPTION
problem: wins uses a copy of the file you want to use with the `cli prc` command. it makes a copy of that file in a local working dir to make sure it has it's own version. if you restart a pod once it will see the copied file there and move to temp to keep a backup. you restart a pod a second time it will not delete the file in TEMP, just move the file again and fail when it exists.
fix: no one really seems to need the copy so we're opting to delete it if it's already there to just let wins move on and bring in the copied exe again.