### PR TITLE
fix: casing for windows syscalls

### DIFF
--- a/pkg/syscalls/route.go
+++ b/pkg/syscalls/route.go
@@ -8,8 +8,8 @@ import (
 var (
 	modiphlpapi = syscall.NewLazyDLL("iphlpapi.dll")
 
-	procGetIPForwardTable    = modiphlpapi.NewProc("GetIPForwardTable")
-	procCreateIPForwardEntry = modiphlpapi.NewProc("CreateIPForwardEntry")
+	procGetIPForwardTable    = modiphlpapi.NewProc("GetIpForwardTable")
+	procCreateIPForwardEntry = modiphlpapi.NewProc("CreateIpForwardEntry")
 )
 
 type IPForwardTable struct {


### PR DESCRIPTION
fixes regression introduced in #54. sycalls are case-sensitive.

Error log:
```
PS C:\Users\capi> wins cli net get
time="2022-03-23T13:55:41Z" level=fatal msg="rpc error: code = Unknown desc = panic Failed to find GetIPForwardTable procedure in iphlpapi.dll: The specified procedure could not be found."
```

minimal repro:
```golang
package main

import (
	"fmt"
	"syscall"
	"unsafe"
)

type IPForwardTable struct {
	NumEntries uint32
	Table      [1]IPForwardRow
}

type IPForwardRow struct {
	ForwardDest      uint32
	ForwardMask      uint32
	ForwardPolicy    uint32
	ForwardNextHop   uint32
	ForwardIfIndex   uint32
	ForwardType      uint32
	ForwardProto     uint32
	ForwardAge       uint32
	ForwardNextHopAS uint32
	ForwardMetric1   uint32
	ForwardMetric2   uint32
	ForwardMetric3   uint32
	ForwardMetric4   uint32
	ForwardMetric5   uint32
}

func main() {
	modiphlpapi := syscall.NewLazyDLL("iphlpapi.dll")
	procGetIpForwardTable := modiphlpapi.NewProc("GetIpForwardTable")
	//procGetIPForwardTable := modiphlpapi.NewProc("GetIPForwardTable")
	b := make([]byte, 1)
	ft := (*IPForwardTable)(unsafe.Pointer(&b[0]))
	ol := uint32(0)
	var _p0 uint32 = 0
	var errcode error
	//r0, _, _ := syscall.Syscall(procGetIPForwardTable.Addr(), 3, uintptr(unsafe.Pointer(ft)), uintptr(unsafe.Pointer(&ol)), uintptr(_p0))
	//if r0 != 0 {
	//	errcode = syscall.Errno(r0)
	//}
	//fmt.Println(errcode, procGetIPForwardTable)

	r01, _, _ := syscall.Syscall(procGetIpForwardTable.Addr(), 3, uintptr(unsafe.Pointer(ft)), uintptr(unsafe.Pointer(&ol)), uintptr(_p0))
	if r01 != 0 {
		errcode = syscall.Errno(r01)
	}
	fmt.Println(errcode, procGetIpForwardTable)
}
```

Works with `GetIp`, does not work with `GetIP`. 

Official docs also say CamelCase: https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getipforwardtable