### PR TITLE
bump version of csi-proxy in README to support Windows Server 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Example:
 ```YAML
 csi-proxy:
   url: https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz
-  version: v1.0.0
+  version: v1.1.1
   kubeletPath: c:/etc/kubelet.exe
 ```
 


### PR DESCRIPTION
csi-proxy did not support 2022 until v1.1.1 per https://github.com/kubernetes-csi/csi-proxy/commit/2a1dfdb670b6e8efbc987b6347e59dbcea35c97d

This was not documented or mentioned in a release-note in the csi-proxy repo