### PR TITLE
fix import cycle, enhance stackdump info message

### DIFF
--- a/cmd/cmds/tools.go
+++ b/cmd/cmds/tools.go
@@ -4,6 +4,11 @@ import (
 	"github.com/urfave/cli"
 )
 
+func BoolAddr(b bool) *bool {
+	boolVar := b
+	return &boolVar
+}
+
 func JoinFlags(flagSlices ...[]cli.Flag) []cli.Flag {
 	var ret []cli.Flag
 	for _, flags := range flagSlices {

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rancher/wins/cmd/cmds"
-
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/rancher/system-agent/pkg/config"
+	"github.com/rancher/wins/cmd/cmds"
 	"github.com/rancher/wins/pkg/csiproxy"
 	"github.com/rancher/wins/pkg/defaults"
 	"github.com/rancher/wins/pkg/tls"

--- a/pkg/csiproxy/csi.go
+++ b/pkg/csiproxy/csi.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	winsConfig "github.com/rancher/wins/cmd/server/config"
 	"github.com/rancher/wins/pkg/concierge"
 	"github.com/rancher/wins/pkg/tls"
 )
@@ -26,6 +25,7 @@ type Config struct {
 	URL         string `yaml:"url" json:"url"`
 	Version     string `yaml:"version" json:"version"`
 	KubeletPath string `yaml:"kubeletPath" json:"kubeletPath"`
+	tls.Config
 }
 
 // Validate ensures that the configuration for CSI Proxy is correct if provided.
@@ -91,9 +91,9 @@ func (p *Proxy) Enable() error {
 		return err
 	}
 	if !ok {
-		wc := winsConfig.Config{}
-		if wc.TLSConfig.CertFilePath != "" {
-			_, err := tls.SetupGenericTLSConfigFromFile(*wc.TLSConfig)
+		if p.cfg.CertFilePath != "" && !*p.cfg.Insecure {
+			// CSI Proxy does not need the certpool that is returned
+			_, err := tls.SetupGenericTLSConfigFromFile()
 			if err != nil {
 				return err
 			}

--- a/pkg/profilings/stack.go
+++ b/pkg/profilings/stack.go
@@ -76,7 +76,7 @@ func SetupDumpStacks(serviceName string, pid int, cwd string) {
 	}
 
 	go func() {
-		logrus.Infof("Stackdump - waiting signal at %s", event)
+		logrus.Infof("[SetupDumpStacks] stackdump feature successfully initialized - waiting for signal at %s", event)
 		for {
 			windows.WaitForSingleObject(h, windows.INFINITE)
 			fileLoc := filepath.Join(cwd, fmt.Sprintf("%s.%d.stacks.log", serviceName, pid))

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -9,13 +9,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type TLSConfig struct {
+type Config struct {
 	Insecure     *bool  `yaml:"insecure" json:"insecure"`
 	CertFilePath string `yaml:"CertFilePath" json:"CertFilePath"`
 }
 
 // SetupGenericTLSConfigFromFile returns a x509 system certificate pool containing the specified certificate file
-func SetupGenericTLSConfigFromFile(config TLSConfig) (*x509.CertPool, error) {
+func SetupGenericTLSConfigFromFile() (*x509.CertPool, error) {
+	var config *Config
 	if config.CertFilePath == "" {
 		logrus.Info("[SetupGenericTLSConfigFromFile] specified certificate file path is empty, not modifying system certificate store")
 		return nil, nil


### PR DESCRIPTION
I created an import cycle in my last PR, this fixes it and also addresses feedback from QA that the informational stackdump message logged once the wins server has started up does not indicate that it is informational.