### PR TITLE
fix tlsConfig for csi proxy and install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -468,7 +468,7 @@ white_list:
   proxyPorts:
     - 9796
 "@
-        Set-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $winsConfig
+        Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $winsConfig
 
         $agentConfig = 
         @"
@@ -477,6 +477,8 @@ systemagent:
   appliedPlanDirectory: $($env:CATTLE_AGENT_VAR_DIR)/applied
   remoteEnabled: $($env:CATTLE_REMOTE_ENABLED)
   preserveWorkDirectory: $($env:CATTLE_PRESERVE_WORKDIR)
+tls-config:
+  certFilePath: C:/etc/rancher/wins/ranchercert
 "@
         Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $agentConfig
         if ($env:CATTLE_REMOTE_ENABLED -eq "true") {

--- a/install.ps1
+++ b/install.ps1
@@ -472,13 +472,13 @@ white_list:
 
         $agentConfig = 
         @"
+tls-config:
+  certFilePath: C:/etc/rancher/wins/ranchercert
 systemagent:
   workDirectory: $($env:CATTLE_AGENT_VAR_DIR)/work
   appliedPlanDirectory: $($env:CATTLE_AGENT_VAR_DIR)/applied
   remoteEnabled: $($env:CATTLE_REMOTE_ENABLED)
   preserveWorkDirectory: $($env:CATTLE_PRESERVE_WORKDIR)
-tls-config:
-  certFilePath: C:/etc/rancher/wins/ranchercert
 "@
         Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $agentConfig
         if ($env:CATTLE_REMOTE_ENABLED -eq "true") {

--- a/pkg/csiproxy/csi.go
+++ b/pkg/csiproxy/csi.go
@@ -3,6 +3,7 @@ package csiproxy
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/wins/pkg/concierge"
-	"github.com/rancher/wins/pkg/tls"
+	winstls "github.com/rancher/wins/pkg/tls"
 )
 
 const (
@@ -25,7 +26,7 @@ type Config struct {
 	URL         string `yaml:"url" json:"url"`
 	Version     string `yaml:"version" json:"version"`
 	KubeletPath string `yaml:"kubeletPath" json:"kubeletPath"`
-	tls.Config
+	winstls.Config
 }
 
 // Validate ensures that the configuration for CSI Proxy is correct if provided.
@@ -93,7 +94,7 @@ func (p *Proxy) Enable() error {
 	if !ok {
 		if p.cfg.CertFilePath != "" && !*p.cfg.Insecure {
 			// CSI Proxy does not need the certpool that is returned
-			_, err := tls.SetupGenericTLSConfigFromFile()
+			_, err := winstls.SetupGenericTLSConfigFromFile()
 			if err != nil {
 				return err
 			}
@@ -125,6 +126,16 @@ func (p *Proxy) download() error {
 			return nil
 		},
 	}
+
+	// default to insecure
+	transport := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	client.Transport = &transport
+
+	if !*p.cfg.Insecure && p.cfg.CertFilePath != "" {
+		transport = http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false}}
+		client.Transport = &transport
+	}
+
 	resp, err := client.Get(fmt.Sprintf(p.cfg.URL, p.cfg.Version))
 	if err != nil {
 		return err
@@ -132,6 +143,7 @@ func (p *Proxy) download() error {
 
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
+		transport.CloseIdleConnections()
 	}(resp.Body)
 
 	gz, err := gzip.NewReader(resp.Body)

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -11,7 +11,7 @@ import (
 
 type Config struct {
 	Insecure     *bool  `yaml:"insecure" json:"insecure"`
-	CertFilePath string `yaml:"CertFilePath" json:"CertFilePath"`
+	CertFilePath string `yaml:"certFilePath" json:"certFilePath"`
 }
 
 // SetupGenericTLSConfigFromFile returns a x509 system certificate pool containing the specified certificate file


### PR DESCRIPTION
This fixes an issue where the install script was over-riding existing wins config as well as sets the default csiProxy http transport to be insecure.

### Summary
Fixes a new bug found while testing https://github.com/rancher/rancher/issues/36732 and https://github.com/rancher/rancher/issues/36574

### Occurred changes and/or fixed issues

- do not override the wins config when using the wins install script
- ensure that the default certFilePath in wins config is empty for non-rancher users
- set certFilePath as part of the wins install script
- call ValidateTLSConfig as part of wins config validation
- default to using an insecure http transport to match system-agent functionality

### Technical notes summary

in csi.go, we are now specifying an http.Transport struct as it is the only way to mimic a `--insecure` that is used in the system-agent scripts.

### Areas or cases that should be tested

I tested the install script on a windows machine

### Areas which could experience regressions

I don't see any areas of possible regressions.

### Screenshot/Video