### PR TITLE
check if tls-config is valid/present before setting certFilePath + add PR tempate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- This template is for Devs to give QA details before moving the issue To-Test -->
+### Summary
+Fixes #
+<!-- Define findings related to the feature or bug issue. -->
+
+### Occurred changes and/or fixed issues
+<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
+
+### Technical notes summary
+<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
+
+### Areas or cases that should be tested
+<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
+<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
+
+### Areas which could experience regressions
+<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
+
+### Screenshot/Video
+<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -75,8 +75,10 @@ func (c *Config) Validate() error {
 	}
 
 	// validate csiProxy config
-	if err := c.ValidateTLSConfig(); err != nil {
-		return errors.Wrap(err, "[Validate] failed to validate tls-config field")
+	if c.TLSConfig.CertFilePath != "" {
+		if err := c.ValidateTLSConfig(); err != nil {
+			return errors.Wrap(err, "[Validate] failed to validate tls-config field")
+		}
 	}
 	return nil
 }

--- a/install.ps1
+++ b/install.ps1
@@ -472,8 +472,6 @@ white_list:
 
         $agentConfig = 
         @"
-tls-config:
-  certFilePath: C:/etc/rancher/wins/ranchercert
 systemagent:
   workDirectory: $($env:CATTLE_AGENT_VAR_DIR)/work
   appliedPlanDirectory: $($env:CATTLE_AGENT_VAR_DIR)/applied
@@ -483,6 +481,14 @@ systemagent:
         Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $agentConfig
         if ($env:CATTLE_REMOTE_ENABLED -eq "true") {
             Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value "  connectionInfoFile: $env:CATTLE_AGENT_VAR_DIR/rancher2_connection_info.json"
+        }
+        if ((Test-Path -Path $env:RANCHER_CERT) -and ($env:CA_REQUIRED -eq "true")) {
+            $tlsConfig =
+            @"
+            tls-config:
+                certFilePath: $($($env:RANCHER_CERT).Replace("\\","/"))
+"@
+            Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $tlsConfig
         }
     }
 


### PR DESCRIPTION
### Summary
- Addresses bug found during testing for https://github.com/rancher/rancher/issues/37628


### Occurred changes and/or fixed issues
- Fixes an issue where the `certFilePath` was set in the wins installation script without checking if the file path was valid and a certificate was required
- check if tls-config is valid/present before setting certFilePath

### Technical notes summary

By moving the tls-config logic in the install script behind an `if (Test-Path -Path $env:RANCHER_CERT) -and ($env:CA_REQUIRED -eq "true")`, this ensures that wins will only set the tls-config if the requirements are met.

### Areas or cases that should be tested
standard installation of wins (system-agent for Windows) via the install script.

### Areas which could experience regressions

No regressions are expected.

### Screenshot/Video
Unavailable.