### PR TITLE
set windows registry values for proxy

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -632,6 +632,11 @@ csi-proxy:
         $newEnv = @()
         $PROXY_ENV_INFO = Get-ChildItem env: | Where-Object { $_.Name -Match "^(NO|HTTP|HTTPS)_PROXY" } | ForEach-Object { "$($_.Name)=$($_.Value)" }
         if ($PROXY_ENV_INFO) {
+            netsh winhttp set proxy $env:HTTPS_PROXY
+            Set-ItemProperty -path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings" ProxyEnable -value 1
+            Set-ItemProperty -path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings" ProxyServer -value "https=$env:HTTPS_PROXY;http=$env:HTTP_PROXY"
+            Set-ItemProperty -path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings" ProxyOverride -value $env:NO_PROXY.Replace(',',';')
+
             $newEnv += $PROXY_ENV_INFO
             if(Test-Path -Path HKLM:SYSTEM\CurrentControlSet\Services\$serviceName) {
                 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$serviceName -Name Environment -Value $([string]$newEnv)


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes an issue in https://github.com/rancher/rancher/issues/36574
Fixes an issue in https://github.com/rancher/rancher/issues/36732


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

the wins install script will now set the proper proxy registry keys if the environment proxy variables are detected.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

in the system-agent implementation of wins, using a proxy was not working as expected due to the registry values not being set for the proxy. This is a change 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

installation of windows worker nodes via system-agent (wins) behind a proxy

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

none, as this functionality is currently broken.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->