### PR TITLE
Removing all Windows 20H2 support since it is EOL August 9th.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,74 +81,6 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: windows-20H2
-
-platform:
-  os: windows
-  arch: amd64
-  version: 20H2
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-- name: clone
-  image: rancher/drone-images:git-20H2
-
-- name: build
-  pull: always
-  image: rancher/dapper:v0.5.8
-  commands:
-    - dapper.exe -f Dockerfile.dapper -d ci
-  volumes:
-    - name: docker_pipe
-      path: \\\\.\\pipe\\docker_engine
-
-- name: stage-binaries
-  image: rancher/dapper:v0.5.8
-  commands:
-    - "Get-ChildItem -Path ./bin; Get-ChildItem -Path ./dist; Copy-Item -Force -Path ./bin/wins.exe -Destination ./package/windows/; Get-ChildItem -Path ./package/windows"
-
-- name: docker-publish
-  image: rancher/drone-images:docker-20H2
-  settings:
-    build_args:
-      - SERVERCORE_VERSION=20H2
-      - ARCH=amd64
-      - VERSION=${DRONE_TAG}
-    context: package/windows
-    custom_dns: 1.1.1.1
-    dockerfile: package/windows/Dockerfile
-    username:
-      from_secret: docker_username
-    password:
-      from_secret: docker_password
-    repo: rancher/wins
-    tag: ${DRONE_TAG}-windows-20H2
-  volumes:
-    - name: docker_pipe
-      path: \\\\.\\pipe\\docker_engine
-  when:
-    event:
-      - tag
-    ref:
-      - refs/heads/main
-      - refs/tags/*
-
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-      - promote
-
----
-kind: pipeline
-type: docker
 name: windows-ltsc2022
 
 platform:
@@ -242,7 +174,6 @@ trigger:
 
 depends_on:
 - windows-1809
-- windows-20H2
 - windows-ltsc2022
 
 ---

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -7,12 +7,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/wins:{{build.tag}}-windows-20H2
-    platform:
-      architecture: amd64
-      os: windows
-      version: 20H2
-  -
     image: rancher/wins:{{build.tag}}-windows-ltsc2022
     platform:
       architecture: amd64

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -29,7 +29,7 @@ if ($env:DRONE_TAG) {
     $TAG = $env:DRONE_TAG
 }
 
-$buildTags = @{ "17763" = "1809"; "19042" = "20H2"; "20348" = "ltsc2022";}
+$buildTags = @{ "17763" = "1809"; "20348" = "ltsc2022";}
 $buildNumber = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).CurrentBuildNumber
 $WINDOWS_VERSION = $buildTags[$buildNumber]
 if (-not $WINDOWS_VERSION) {

--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -27,7 +27,7 @@ if (-not $ARCH) {
 }
 $env:ARCH = $ARCH
 
-$buildTags = @{ "17763" = "1809"; "19042" = "20H2"; "20348" = "ltsc2022";}
+$buildTags = @{ "17763" = "1809"; "20348" = "ltsc2022";}
 $buildNumber = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).CurrentBuildNumber
 $SERVERCORE_VERSION = $buildTags[$buildNumber]
 if (-not $SERVERCORE_VERSION) {

--- a/tests/integration/integration_suite_test.ps1
+++ b/tests/integration/integration_suite_test.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 
 # docker build
-$buildTags = @{ "17763" = "1809"; "19042" = "20H2"; "20348" = "ltsc2022";}
+$buildTags = @{ "17763" = "1809"; "20348" = "ltsc2022";}
 $buildNumber = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).CurrentBuildNumber
 $SERVERCORE_VERSION = $buildTags[$buildNumber]
 if (-not $SERVERCORE_VERSION) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This removes Windows 20H2 from the build, images, tests, and manifest since it is EOL come August 9th, 2022.

* https://github.com/rancher/windows/issues/113

### Occurred changes and/or fixed issues

Removed the build pipeline, manifest entry, and tests for Windows 2022.
