### PR TITLE
Tweaks for Wins upgrades and system agent bump.

### DIFF
--- a/charts/rancher-wins-upgrader/README.md
+++ b/charts/rancher-wins-upgrader/README.md
@@ -1,5 +1,7 @@
 # Rancher Wins Upgrader
 
+# **This is chart is deprecated and will not be maintained starting at v0.3.0.**
+
 A Rancher chart that handles keeping the wins server version and config across some (or all) of the Windows nodes on a Kubernetes cluster in sync. It does this by running a simple script to replace the contents of the `\etc\rancher\wins` directory with the newly specified config and wins image via one or more DaemonSets. Once executed, the script will simply sleep forever.
 
 ## How does this work?

--- a/charts/rancher-wins-upgrader/app-readme.md
+++ b/charts/rancher-wins-upgrader/app-readme.md
@@ -1,5 +1,7 @@
 # Rancher Wins Upgrader
 
+# **This is chart is deprecated and will not be maintained starting at v0.3.0.**
+
 A Rancher chart that handles keeping the wins server version and config across some (or all) of the Windows nodes on a Kubernetes cluster in sync. It does this by running a simple script to replace the contents of the `\etc\rancher\wins` directory with the newly specified config and wins image via one or more DaemonSets. Once executed, the script will simply sleep forever.
 
 ## How does this work?

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/rancher/remotedialer v0.2.6-0.20201012155453-8b1b7bb7d05f
-	github.com/rancher/system-agent v0.2.7
+	github.com/rancher/system-agent v0.2.8
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/urfave/cli v1.22.5

--- a/go.sum
+++ b/go.sum
@@ -588,8 +588,8 @@ github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d h1:vfjPEF6M7Jf1/zK1x
 github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/remotedialer v0.2.6-0.20201012155453-8b1b7bb7d05f h1:FIZcYXY/dl18TN1UdA18PRbTB7UfmylSVjpD/4gmF34=
 github.com/rancher/remotedialer v0.2.6-0.20201012155453-8b1b7bb7d05f/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
-github.com/rancher/system-agent v0.2.7 h1:R2M33BkT9LB+vf5Q8D0XvrVlgbv419UMOh1ABKC+lRk=
-github.com/rancher/system-agent v0.2.7/go.mod h1:m0YpDXKOalr3PEM9xZWdrASA2CznUIzFfPnwKYp6Mtk=
+github.com/rancher/system-agent v0.2.8 h1:kf1cwfhdafg3j4Tum1AtdNuANDUoAHvovLoG4kwNhT8=
+github.com/rancher/system-agent v0.2.8/go.mod h1:m0YpDXKOalr3PEM9xZWdrASA2CznUIzFfPnwKYp6Mtk=
 github.com/rancher/wharfie v0.4.3 h1:Ezn78XQLvfFb02NYG7IlsnCNsQo1upLYoIxAidQJans=
 github.com/rancher/wharfie v0.4.3/go.mod h1:cb8mSczpmw7ItbPF3K1W7crWuJLVdyV49sZZuaY4BS8=
 github.com/rancher/wrangler v0.8.0 h1:jGWr7ES0KwZU/8zB6lte0z4QB7hFcspaXPTvGmrvHok=

--- a/suc/run.ps1
+++ b/suc/run.ps1
@@ -109,9 +109,8 @@ function Invoke-WinsWinsUpgrade {
     }
 
     $winsOut = wins.exe cli prc run --path=$winsUpgradePathLocal --args="up"
-    Write-Host $winsOut
 
-    #Remove-Item -Path $winsUpgradePath
+    Remove-Item -Path $winsUpgradePath
 
     if ($winsOut -match ".* rpc error: code = Unavailable desc = transport is closing") {
         Write-Host "Successfully upgraded"
@@ -119,10 +118,12 @@ function Invoke-WinsWinsUpgrade {
     }
     elseif ($LastExitCode -ne 0) {
         Write-Host "Returned exit $LastExitCode"
+        Write-Host $winsOut
         exit $LastExitCode
     }
     else {
         Write-Host "Returned exit 0, but did not receive expected output from .\wins up"
+        Write-Host $winsOut
         exit 1
     }  
 }


### PR DESCRIPTION
This deprecates the wins-upgrader chart, tweaks the suc script, and bumps the system agent.

https://github.com/rancher/windows/issues/181