### PR TITLE
read proxy config from env vars for csi-proxy download

### DIFF
--- a/pkg/csiproxy/csi.go
+++ b/pkg/csiproxy/csi.go
@@ -134,7 +134,9 @@ func (p *Proxy) download() error {
 	}
 
 	// default to insecure which matches system-agent functionality
-	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	// if a proxy is set with the proper envvars, we will use it
+	// as long as the req does not match an entry in no_proxy env var
+	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, Proxy: http.ProxyFromEnvironment}
 
 	if p.tlsCfg != nil && !*p.tlsCfg.Insecure && p.tlsCfg.CertFilePath != "" {
 		transport.TLSClientConfig.InsecureSkipVerify = false


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/rancher/issues/36574
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Ensure that we attempt to load proxy configuration from environment variables when downloading the csi-proxy tarball.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`ProxyFromEnvironment` is supposed to work the same on both Linux and Windows per https://pkg.go.dev/net/http#ProxyFromEnvironment

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Any use-cases involving a proxy to reach internal/external network addresses

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

No regressions should occur.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->