### PR TITLE
move binary publish step to after container image publish

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,24 +28,6 @@ steps:
     - name: docker_pipe
       path: \\\\.\\pipe\\docker_engine
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    checksum:
-    - sha256
-    files:
-      - bin/wins.exe
-  when:
-    instance:
-      - drone-publish.rancher.io
-    ref:
-      - refs/head/main
-      - refs/tags/*
-    event:
-      - tag
-
 - name: publish
   image: plugins/docker
   settings:
@@ -68,6 +50,24 @@ steps:
   volumes:
     - name: docker_pipe
       path: \\\\.\\pipe\\docker_engine
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      - refs/head/main
+      - refs/tags/*
+    event:
+      - tag
+
+- name: github_binary_release
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    checksum:
+      - sha256
+    files:
+      - bin/wins.exe
   when:
     instance:
       - drone-publish.rancher.io
@@ -125,7 +125,7 @@ steps:
 
 
   - name: publish
-    image: plugins/docker
+    image: rancher/drone-images:docker-amd64-ltsc2022
     settings:
       no_cache: true
       build_args:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes issues:
- Windows Server 2022 is not supported by upstream Drone plugins, use Rancher image instead
- move binary publish step to after container image publish
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->