### PR TITLE
use temp volume to persist binary from publish step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,8 @@ steps:
   volumes:
     - name: docker_pipe
       path: \\\\.\\pipe\\docker_engine
+    - name: binary_cache
+      path: C:\\package
   when:
     instance:
       - drone-publish.rancher.io
@@ -66,8 +68,14 @@ steps:
       from_secret: github_token
     checksum:
       - sha256
+      - sha512
     files:
-      - C:\package\wins.exe
+      - C:\\package\\wins.exe
+    file_exists:
+      - fail
+  volumes:
+    - name: binary_cache
+      path: C:\\package
   when:
     instance:
       - drone-publish.rancher.io
@@ -81,6 +89,8 @@ volumes:
   - name: docker_pipe
     host:
       path: \\\\.\\pipe\\docker_engine
+  - name: binary_cache
+    path: {}
 
 trigger:
   event:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

We are having an issue with the github binary release plugin for drone. The documentation is lacking on the drone side and due to this being a release blocker, I have opted for a faster path of using a temporary volume

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->