### PR TITLE
Revert EventLog support for SUC script back to Write-Host

### DIFF
--- a/suc/run.ps1
+++ b/suc/run.ps1
@@ -24,12 +24,12 @@ function New-Directory {
     if (Test-Path -Path $Path) {
         if (-not (Test-Path -Path $Path -PathType Container)) {
             # clean the same path file
-            Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Existing path found on host, recursively cleaning $($Path)"
+            Write-Host "Existing path found on host, recursively cleaning $($Path)"
             Remove-Item -Recurse -Force -Path $Path -ErrorAction Ignore | Out-Null
         }
         return
     }
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Creating $($Path)"
+    Write-Host "Creating $($Path)"
     New-Item -Force -ItemType Directory -Path $Path | Out-Null
 }
 
@@ -58,7 +58,7 @@ function Start-TransferFile {
     }
 
     Copy-Item -Force -Path $Source -Destination $Destination | Out-Null
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Transferred file to $Destination from $Source"
+    Write-Host "Transferred file to $Destination from $Source"
 }
 
 function Invoke-WinsHostProcessUpgrade {
@@ -68,9 +68,9 @@ function Invoke-WinsHostProcessUpgrade {
     New-Directory -Path $tmpdir
 
     Start-TransferFile -Source "C:\wins.exe" -Destination  $tmpdir
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Transferred C:\wins.exe to $($tmpdir)"
+    Write-Host "Transferred C:\wins.exe to $($tmpdir)"
     Start-TransferFile -Source "C:\install.ps1" -Destination $tmpdir
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Transferred C:\install.ps1 to $($tmpdir)"
+    Write-Host "Transferred C:\install.ps1 to $($tmpdir)"
 
     if (-Not $env:CATTLE_ROLE_WORKER) {
         $env:CATTLE_ROLE_WORKER = "true"
@@ -81,26 +81,16 @@ function Invoke-WinsHostProcessUpgrade {
 
     Set-Location -Path $tmpdir
 
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Running install.ps1 in $($tmpdir)"
+    Write-Host "Running install.ps1 in $($tmpdir)"
     ./install.ps1
 
     Pop-Location
 
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Successfully ran install.ps1, cleaning $($tmpdir)\wins.exe"
+    Write-Host "Successfully ran install.ps1, cleaning $($tmpdir)\wins.exe"
     Remove-Item -Force -Path $tmpdir\wins.exe -ErrorAction Ignore | Out-Null
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Successfully ran install.ps1, cleaning $($tmpdir)\install.ps1"
+    Write-Host "Successfully ran install.ps1, cleaning $($tmpdir)\install.ps1"
     Remove-Item -Force -Path $tmpdir\install.ps1 -ErrorAction Ignore | Out-Null
     exit 0
-}
-
-function Invoke-LogWrite {
-    param (
-        [parameter(Mandatory = $true)] [string]$Message,
-        [parameter(Mandatory = $true)] [string]$LogName,
-        [parameter(Mandatory = $true)] [string]$Source
-    )
-    Write-Host "$($Message)"
-    Write-EventLog -LogName "$LogName" -Source "$Source" -Message "$Message" -EID 1
 }
 
 function Invoke-WinsWinsUpgrade {
@@ -111,24 +101,24 @@ function Invoke-WinsWinsUpgrade {
     $winsUpgradePathLocal = Join-Path -Path $tmpdirLocal -ChildPath "wins-upgrade.exe"
 
     New-Directory -Path $tmpdirLocal
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Created new directory $($tmpdirLocal)"
+    Write-Host "Created new directory $($tmpdirLocal)"
     Copy-Item -Force -Path "C:\wins.exe" -Destination $winsUpgradePathLocal | Out-Null
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Copied C:\wins.exe to $($winsUpgradePathLocal)"
+    Write-Host "Copied C:\wins.exe to $($winsUpgradePathLocal)"
 
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Transferring file to host..."
+    Write-Host "Transferring file to host..."
     New-Directory -Path $winsUpgradePath
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Created new directory $($winsUpgradePath)"
+    Write-Host "Created new directory $($winsUpgradePath)"
     Start-TransferFile -Source "C:\wins.exe" -Destination $winsUpgradePath
 
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Checking if $($winsUpgradePath) exists"
+    Write-Host "Checking if $($winsUpgradePath) exists"
     if(Test-Path $winsUpgradePath) {
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message "$($winsUpgradePath) exists..."
+        Write-Host "$($winsUpgradePath) exists..."
     }
     else {
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message "$($winsUpgradePath) was not copied to host..."
+        Write-Host "$($winsUpgradePath) was not copied to host..."
         exit 1
     }
-    Invoke-LogWrite -LogName Application -Source rancher-wins -Message "preparing to run wins.exe upgrade using $($winsUpgradePathLocal)"
+    Write-Host "preparing to run wins.exe upgrade using $($winsUpgradePathLocal)"
 
     $winsOut = wins.exe cli prc run --path=$winsUpgradePathLocal --args="up"
 
@@ -136,17 +126,17 @@ function Invoke-WinsWinsUpgrade {
 
 
     if ($winsOut -match ".* rpc error: code = Unavailable desc = transport is closing" -or ".* rpc error: code = Unavailable desc = error reading from server: EOF") {
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Successfully upgraded"
+        Write-Host "Successfully upgraded"
         exit 0
     }
     elseif ($LastExitCode -ne 0) {
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Returned exit $LastExitCode"
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message $winsOut
+        Write-Host "Returned exit $LastExitCode"
+        Write-Host $winsOut
         exit $LastExitCode
     }
     else {
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message "Returned exit 0, but did not receive expected output from .\wins up"
-        Invoke-LogWrite -LogName Application -Source rancher-wins -Message $winsOut
+        Write-Host "Returned exit 0, but did not receive expected output from .\wins up"
+        Write-Host -Message $winsOut
         exit 1
     }  
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/rancher/issues/38896 and https://github.com/rancher/rancher/issues/38915

### Occurred changes and/or fixed issues
A change was made in PR https://github.com/rancher/wins/pull/141 that changed logs to being written to both the EventLog and host. The issue with this is that the EventLog didn't exist within the container, and rather than attempt to create the containerized EventLog, it's probably easier to just write logs to the host. 

This PR retains the increased log verbosity but does not attempt to write to the EventLog anymore.

### Technical notes summary


### Areas or cases that should be tested
We should make sure the SUC image still works.

### Areas which could experience regressions
The SUC image.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->