### PR TITLE
Update Maintainers, Add Integration Target, Update README

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,7 @@ steps:
     build_args:
       - SERVERCORE_VERSION=1809
       - ARCH=amd64
-      - MAINTAINERS=rosskirkpat@outlook.com cphill11@gmail.com luther.monson@gmail.com
+      - MAINTAINERS=harrison.affel@suse.com arvind.iyengar@suse.com
       - REPO=https://github.com/rancher/wins
     custom_dns: 1.1.1.1
     dockerfile: Dockerfile
@@ -129,7 +129,7 @@ steps:
       build_args:
         - SERVERCORE_VERSION=ltsc2022
         - ARCH=amd64
-        - MAINTAINERS=rosskirkpat@outlook.com cphill11@gmail.com luther.monson@gmail.com
+        - MAINTAINERS=harrison.affel@suse.com arvind.iyengar@suse.com
         - REPO=https://github.com/rancher/wins
       custom_dns: 1.1.1.1
       dockerfile: Dockerfile

--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ OPTIONS:
 git clone https://github.com/rancher/wins.git
 Set-Location wins
 Set-Location $(Get-Location).path
-scripts/build.ps1
+
+# build the project using the magefile
+go run mage.go build
+
 copy-item bin/wins.exe .
 $WINS_PATH = $(Get-Location).Path
 
@@ -237,17 +240,17 @@ For integration test, please run the below command in `PowerShell`:
 > go run mage.go integration
 ```
 
-> Note: Don't use `bin/wins.exe` after integration testing. Please `.\make.ps1 build` again.
+> Note: Don't use `bin/wins.exe` after integration testing. Please `go run mage.go build` again.
 
 If want both of them, please run the below command in `PowerShell`:
 
 ``` powershell
-> .\make.ps1 all
+> go run mage.go TestAll
 ```
 
 ## License
 
-Copyright (c) 2014-2022 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2014-2023 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.24.0
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.8
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.0
-
 )
 
 require (
@@ -58,12 +57,8 @@ require (
 	golang.org/x/sys v0.10.0
 	google.golang.org/grpc v1.45.0
 	inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
-
-)
-
-require github.com/magefile/mage v1.13.0
-
-require (
+	github.com/magefile/mage v1.13.0
+	k8s.io/client-go v0.24.2
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -132,7 +127,6 @@ require (
 	k8s.io/api v0.24.2 // indirect
 	k8s.io/apimachinery v0.24.2 // indirect
 	k8s.io/apiserver v0.24.0 // indirect
-	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.70.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/tests/integration/docker/Dockerfile.wins-cli
+++ b/tests/integration/docker/Dockerfile.wins-cli
@@ -1,5 +1,5 @@
 ARG SERVERCORE_VERSION
 
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
-COPY bin/wins-container.exe /Windows/wins.exe
+COPY bin/wins.exe /Windows/wins.exe
 ENTRYPOINT wins.exe cli

--- a/tests/integration/docker/Dockerfile.wins-nginx
+++ b/tests/integration/docker/Dockerfile.wins-nginx
@@ -16,6 +16,6 @@ RUN $URL = 'http://nginx.org/download/nginx-1.21.3.zip'; \
     Remove-Item -Force -Path c:\nginx.zip | Out-Null; \
     \
     Write-Host 'Complete.'
-COPY bin/wins-container.exe /Windows/wins.exe
+COPY bin/wins.exe /Windows/wins.exe
 COPY tests/integration/docker/nginx.ps1 /Windows/
 ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "c:/Windows/nginx.ps1"]

--- a/tests/integration/docker/Dockerfile.wins-upgrade
+++ b/tests/integration/docker/Dockerfile.wins-upgrade
@@ -2,6 +2,6 @@ ARG SERVERCORE_VERSION
 
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-COPY bin/wins-container.exe /Windows/wins.exe
+COPY bin/wins.exe /Windows/wins.exe
 COPY tests/integration/docker/upgrade.ps1 /Windows/
 ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "c:/Windows/upgrade.ps1"]

--- a/tests/integration/integration_suite_test.ps1
+++ b/tests/integration/integration_suite_test.ps1
@@ -8,18 +8,18 @@ if (-not $SERVERCORE_VERSION) {
     $SERVERCORE_VERSION = "1809"
 }
 
-#Get-ChildItem -Path $PSScriptRoot\docker -Name Dockerfile.* | ForEach-Object {
-#    $dockerfile = $_
-#    $tag = $dockerfile -replace "Dockerfile.", ""
-#    docker build `
-#        --build-arg SERVERCORE_VERSION=$SERVERCORE_VERSION `
-#        -t $tag `
-#        -f $PSScriptRoot\docker\$dockerfile .
-#    if ($LASTEXITCODE -ne 0) {
-#        Log-Fatal "Failed to build testing docker image"
-#        exit $LASTEXITCODE
-#    }
-#}
+Get-ChildItem -Path $PSScriptRoot\docker -Name Dockerfile.* | ForEach-Object {
+    $dockerfile = $_
+    $tag = $dockerfile -replace "Dockerfile.", ""
+    docker build `
+        --build-arg SERVERCORE_VERSION=$SERVERCORE_VERSION `
+        -t $tag `
+        -f $PSScriptRoot\docker\$dockerfile .
+    if ($LASTEXITCODE -ne 0) {
+        Log-Fatal "Failed to build testing docker image"
+        exit $LASTEXITCODE
+    }
+}
 
 # test
 New-Item -Type Directory -Force -ErrorAction Ignore -Path @(


### PR DESCRIPTION
### Summary

+ Update `README.md` to remove references to old powershell scripts which are no longer used 
+ Update `MAINTAINERS` in drone.yml
+ Add new mage build targets so integration tests can be manually run  
   + Integration tests are not run in drone, only unit tests are 
   + A prior PR completely removed scripts / targets needed to run the integration tests during the transition to using mage files, but did not reintroduce a target for the integration tests
+ Update copyright date 
+ coalesce go.mod requirement blocks

If theres some context that I've missed surrounding the changes made to the integration tests let me know, from what I could tell they were in a state of limbo after the departure of Ross and Jamie and felt that adding them back would be useful for local development 