### PR TITLE
Fix pipeline by removing `github.com/onsi/gomega`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,6 @@ steps:
   commands:
     - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
     - go install github.com/onsi/ginkgo/ginkgo@latest
-    - go get github.com/onsi/gomega/...
     - cd ..
     - git clone https://github.com/magefile/mage.git
     - cd mage
@@ -113,7 +112,6 @@ steps:
     commands:
       - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
       - go install github.com/onsi/ginkgo/ginkgo@latest
-      - go get github.com/onsi/gomega/...
       - cd ..
       - git clone https://github.com/magefile/mage.git
       - cd mage


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
For some strange reason `go get github.com/onsi/gomega/...` works in Drone-PR for both Win versions (https://drone-pr.rancher.io/rancher/wins/393) and in Drone-Publish for Win2022 (https://drone-publish.rancher.io/rancher/wins/182/2/2), but fails in Drone-Publish for Win1809 (https://drone-publish.rancher.io/rancher/wins/182/1/2). This PR is removing that dependency from the build pipeline which apparently is not needed.


```
go get github.com/onsi/gomega/...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->