### PR TITLE
Pass X-Cattle-Node-Name header when generating connection info

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -438,7 +438,7 @@ function Invoke-WinsInstaller {
         if ($env:CATTLE_REMOTE_ENABLED -eq "true") {
             $retries = 0              
             while ($retries -lt 6) {
-                $responseCode = $(curl.exe --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" $env:CURL_CAFLAG -sfL "$env:CATTLE_SERVER/v3/connect/agent" -o $env:CATTLE_AGENT_VAR_DIR/rancher2_connection_info.json -H "Authorization: Bearer $($env:CATTLE_TOKEN)" -H "X-Cattle-Id: $($env:CATTLE_ID)" -H "X-Cattle-Role-Worker: $($env:CATTLE_ROLE_WORKER)" -H "X-Cattle-Labels: $($env:CATTLE_LABELS)" -H "X-Cattle-Taints: $($env:CATTLE_TAINTS)" -H "X-Cattle-Address: $($env:CATTLE_ADDRESS)" -H "X-Cattle-Internal-Address: $($env:CATTLE_INTERNAL_ADDRESS)" -H "Content-Type: application/json")
+                $responseCode = $(curl.exe --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" $env:CURL_CAFLAG -sfL "$env:CATTLE_SERVER/v3/connect/agent" -o $env:CATTLE_AGENT_VAR_DIR/rancher2_connection_info.json -H "Authorization: Bearer $($env:CATTLE_TOKEN)" -H "X-Cattle-Node-Name: $($env:CATTLE_NODE_NAME)" -H "X-Cattle-Id: $($env:CATTLE_ID)" -H "X-Cattle-Role-Worker: $($env:CATTLE_ROLE_WORKER)" -H "X-Cattle-Labels: $($env:CATTLE_LABELS)" -H "X-Cattle-Taints: $($env:CATTLE_TAINTS)" -H "X-Cattle-Address: $($env:CATTLE_ADDRESS)" -H "X-Cattle-Internal-Address: $($env:CATTLE_INTERNAL_ADDRESS)" -H "Content-Type: application/json")
                 switch ( $responseCode ) {
                     { $_ -in "ok200", 200 } {
                         Write-LogInfo "Successfully downloaded Rancher connection information."


### PR DESCRIPTION
### Summary
Issue: https://github.com/rancher/rancher/issues/43587

### Occurred changes and/or fixed issues

When obtaining Rancher connection information wins is not specifying a desired node-name. This means that users cannot set custom node names when creating windows nodes within Rancher. The `v3/connect/agent` endpoint uses the `X-Cattle-Node-Name` header to specify what name an incoming node should use, and the current `install.ps1` script does not use that header.

### Areas or cases that should be tested
Adding windows workers to custom clusters using custom node names, as well as adding windows nodes to custom clusters without specifying a custom node name


### Areas which could experience regressions
Adding this additional header should not introduce any potential regressions. Dev testing has shown that this change does not negatively impact node registration when a custom node name is **not** used. 

Scenarios where custom node name values are used incorrectly should not be considered regressions. 