### PR TITLE
Fix issues related to powershell commands and regedit when using a proxy

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -639,11 +639,11 @@ csi-proxy:
 
             $newEnv += $PROXY_ENV_INFO
             if(Test-Path -Path HKLM:SYSTEM\CurrentControlSet\Services\$serviceName) {
-                Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$serviceName -Name Environment -Value $([string]$newEnv)
+                Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$serviceName -Name Environment -Value $newEnv
             }
             else {
                 New-Item HKLM:SYSTEM\CurrentControlSet\Services\$serviceName
-                New-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$serviceName -Name Environment -PropertyType MultiString -Value $([string]$newEnv)
+                New-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$serviceName -Name Environment -PropertyType MultiString -Value $newEnv
             }
         }
                 


### PR DESCRIPTION
## Before this PR 🙁

The missing environment variables `https_proxy` and `no_proxy` appear in the value of the environment variable `http_proxy`.

![wins exe](https://github.com/rancher/wins/assets/77958736/3ddcec6d-93ef-43d6-9b1f-32c81f7dc417)

## After this PR 😀

The environment variables `http_proxy`, `https_proxy`, and `no_proxy` are all correctly set.

![wins exe](https://github.com/rancher/wins/assets/77958736/0c7f6dc9-7f0f-47a9-b5ea-66c8f192e1cb)

## Debugging tool

I use [Sysinternals Process Explorer](https://learn.microsoft.com/en-us/sysinternals/downloads/process-explorer) to check environment variables of the `wins.exe` windows process.

## OS Specifications

- Edition: `Windows Server 2022 Standard`
- Version: `21H2`
- OS build: `20348.2113`

## Technical notes summary

The following example are from official doc. It shows that the value of `MultiString` can be `an array of values`.

> ### Example 4: Create a MultiString value in the registry using an array
>
>The example shows how to use an array of values to create the MultiString value.
>
>```powershell
>$newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'MultiString' -PropertyType MultiString -Value ('a','b','c')
>$newValue.multistring[0]
>
>a
>```

## Related Issues & PRs

- https://github.com/rancher/rancher/issues/43932#issue-2069954251
- https://github.com/rancher/system-agent-installer-rke2/pull/48

## References

- [PowerShell 7.4 Official Doc - Create a MultiString value in the registry using an array](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-itemproperty?view=powershell-7.4#example-4-create-a-multistring-value-in-the-registry-using-an-array)
- [PowerShell 5.1 Official Doc - Create a MultiString value in the registry using an array](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-itemproperty?view=powershell-5.1#example-4-create-a-multistring-value-in-the-registry-using-an-array)
