### PR TITLE
Bump to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/wins
 
-go 1.18
+go 1.21
 
 replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.16+incompatible
@@ -47,6 +47,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/magefile/mage v1.13.0
 	github.com/mattn/go-colorable v0.1.11
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/remotedialer v0.2.6-0.20201012155453-8b1b7bb7d05f
@@ -57,8 +58,9 @@ require (
 	golang.org/x/sys v0.10.0
 	google.golang.org/grpc v1.45.0
 	inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
-	github.com/magefile/mage v1.13.0
-	k8s.io/client-go v0.24.2
+)
+
+require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -127,6 +129,7 @@ require (
 	k8s.io/api v0.24.2 // indirect
 	k8s.io/apimachinery v0.24.2 // indirect
 	k8s.io/apiserver v0.24.0 // indirect
+	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.70.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Addresses
https://github.com/rancher/rancher/issues/45325

### Occurred changes and/or fixed issues
Bumped go version from 1.18 to 1.21

### Technical notes summary
While the `go.mod` file format changed due to the bump, no version changes have occurred in any dependencies

### Areas or cases that should be tested
Once a new wins version is released and bumped in Rancher, provision a custom windows cluster on RKE2

### Areas which could experience regressions
n/a