### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,15 +31,16 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
       - name: Install Dependencies
         run: |
           go install github.com/magefile/mage@v1.15.0
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
       - name: build-binary
         run: |
           set PSModulePath=&&powershell -command "mage ci"
@@ -48,7 +49,7 @@ jobs:
       # which cannot be installed onto windows VMs. Additionally, it is not possible to cross compile
       # Windows images on linux. So, we're stuck with manual docker commands.
       - name: Build Windows 2022
-        run: ./scripts/build-image.ps1 -ServerCoreVersion "ltsc2022" -Repo "${{ env.REPO }}" -Tag "${{ env.TAG }}"
+        run: ./scripts/build-image.ps1 -NanoServerVersion "ltsc2022" -Repo "${{ env.REPO }}" -Tag "${{ env.TAG }}"
 
       - name: push images
         run: | 
@@ -81,15 +82,15 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Install Dependencies
-        run: |
-          go install github.com/magefile/mage@v1.15.0
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
+      - name: Install Dependencies
+        run: |
+          go install github.com/magefile/mage@v1.15.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 
       - name: build-binary
         run: |
@@ -99,7 +100,7 @@ jobs:
       # which cannot be installed onto windows VMs. Additionally, it is not possible to cross compile
       # Windows images on linux. So, we're stuck with manual docker commands.
       - name: Build Windows 2019
-        run: ./scripts/build-image.ps1 -ServerCoreVersion "ltsc2019" -Repo "${{ env.REPO }}" -Tag "${{ env.TAG }}"
+        run: ./scripts/build-image.ps1 -NanoServerVersion "ltsc2019" -Repo "${{ env.REPO }}" -Tag "${{ env.TAG }}"
 
       - name: push images
         run: |


### PR DESCRIPTION
This PR updates the release workflow such that 

1. The latest version of Go is installed before any dependencies are installed using `go get`. Windows runners have go `v1.21.13` installed by default, however wins has bumped its go version to `v1.22`. Downloading the `mage` and `golangci-lint` dependencies before upgrading Go seems to have resulted in build errors (The latest release run showing these build errors can be found [here](https://github.com/rancher/wins/actions/runs/10691838072/job/29639119246)). This was not an issue for prior releases which also installed `mage` and `golangci-lint` before upgrading Go, so this build error is likely related to the many dependency bumps merged in recent PRs.
      + I was able to confirm that installing the latest version of Go before installing `mage` or `golangci-lint` resolved the issue by modifying the PR workflow to mirror the release workflow and raising a PR against my fork. I was able to reproduce the issue with this [run](https://github.com/HarrisonWAffel/wins/actions/runs/10703077699/job/29672766050) ([workflow file](https://github.com/HarrisonWAffel/wins/actions/runs/10703077699/workflow)), and after making these changes the [run passed as expected](https://github.com/HarrisonWAffel/wins/actions/runs/10703228404/job/29673311093) ([workflow file](https://github.com/HarrisonWAffel/wins/actions/runs/10703228404/workflow))

2. The `build-images.ps1` script removed the `ServerCoreVersion` parameter in favor of `NanoServerVersion`. The release workflow was not updated to use this new parameter 
