### PR TITLE
Overwrite the config file during installation if needed

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -477,7 +477,8 @@ white_list:
   proxyPorts:
     - 9796
 "@
-        Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $winsConfig
+        # Overwrite the existing contents of the file using 'Set-Content'
+        Set-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $winsConfig
 
         $agentConfig = 
         @"


### PR DESCRIPTION
### Summary
Issue https://github.com/rancher/rancher/issues/47039

In the event that the install script is run multiple times, the `rancher-wins` config (located at `/etc/rancher/wins/config`) will be continuously appended to. `rancher-wins` is able to handle this case, as the yaml marshaling dependency we use (`github.com/ghodss/yaml`) seems to only consider the last instance of the duplicate fields in the config file (This behavior can be confirmed by executing this go playground https://go.dev/play/p/-yV1GJSQDd-). For this reason, this duplication does not negatively impact any functionality. However, this behavior is messy and does not match the linux system-agent-install script behavior. Ideally, there should be no duplicates in the config file no matter how many times the install script is ran. 

This duplication occurs as the install script only uses the `Add-Content` commandlet to update the config file. In the initial installation this is not a problem, as the file will be empty. In order to address this issue the first call to `Add-Content` has been changed to a call to `Set-Content`, which will [truncate the file before adding new content](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-7.4#description) (more closely matching what we would expect from a function with the name `Set-WinsConfig`). 