### PR TITLE
[v0.4.19] Bump system agent to v0.3.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/remotedialer v0.4.1
-	github.com/rancher/system-agent v0.3.10-rc.1
+	github.com/rancher/system-agent v0.3.10
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.4
 	golang.org/x/sync v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065 h1:nJPrW/DdnSY
 github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065/go.mod h1:PDAb+l6/i6cbSokQ2CuNCgGOT/BHQY2WgZATwPXEyU4=
 github.com/rancher/remotedialer v0.4.1 h1:jwOf2kPRjBBpSFofv1OuZHWaYHeC9Eb6/XgDvbkoTgc=
 github.com/rancher/remotedialer v0.4.1/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
-github.com/rancher/system-agent v0.3.10-rc.1 h1:WjPVxWnHCiEBERgPur5faIDUyIkhb1fBLUEBJjuqkQw=
-github.com/rancher/system-agent v0.3.10-rc.1/go.mod h1:pX+68YRd0Z/7PFgKxTWTq8WweviGTYAo7kCz2RsUK3g=
+github.com/rancher/system-agent v0.3.10 h1:WgvwcAJzz2+EqPhhu9p0jTpVdxB1SUfI9aFbID8civw=
+github.com/rancher/system-agent v0.3.10/go.mod h1:pX+68YRd0Z/7PFgKxTWTq8WweviGTYAo7kCz2RsUK3g=
 github.com/rancher/wharfie v0.6.7 h1:BhbBVJSLoDQMkZb+zVTLEKckUbq4sc3ZmEYqGakggSY=
 github.com/rancher/wharfie v0.6.7/go.mod h1:ew49A9PzRsTngdzXIkgakfhMq3mHMA650HS1OVQpaNA=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=


### PR DESCRIPTION
This PR bumps `rancher/system-agent` to `v0.3.10` from `v0.3.10-rc.1`. 