### PR TITLE
[v0.4] Remove support for service configuration via the SUC

### DIFF
--- a/suc/pkg/cmd.go
+++ b/suc/pkg/cmd.go
@@ -37,18 +37,6 @@ func Run(_ *cli.Context) error {
 		errs = append(errs, updateErr)
 	}
 
-	// Neither changing the start type nor service
-	// dependencies require any service restarts
-	err = service.ConfigureWinsDelayedStart()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	err = service.ConfigureRKE2ServiceDependency()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
 	if restartServiceDueToConfigChange {
 		err = service.RefreshWinsService()
 		if err != nil {

--- a/suc/pkg/service/configure.go
+++ b/suc/pkg/service/configure.go
@@ -2,92 +2,10 @@ package service
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/rancher/wins/pkg/defaults"
 	"github.com/sirupsen/logrus"
 )
-
-// ConfigureRKE2ServiceDependency creates a service dependency between rke2 and rancher-wins. This results in
-// rancher-wins becoming a dependant service for rke2, preventing rke2 startup until rancher-wins is ready. This
-// ensures that rancher-wins and rke2 do not interfere one another during start up (For example, due to CNI reconfiguration).
-// As a side effect, the rancher-wins service cannot be stopped if rke2 is still running. To restart rancher-wins,
-// this dependency must be temporarily removed.
-func ConfigureRKE2ServiceDependency() error {
-	logrus.Info("Configuring rke2 service dependencies")
-	add := strings.ToLower(os.Getenv("CATTLE_ENABLE_WINS_SERVICE_DEPENDENCY")) == "true"
-
-	rke2, serviceExists, err := OpenRKE2Service()
-	if err != nil {
-		return fmt.Errorf("failed to open rke2 service while configuring service dependencies: %w", err)
-	}
-
-	if !serviceExists {
-		logrus.Warn("Could not find rke2 service, will not attempt to configure service dependencies")
-		return nil
-	}
-	defer rke2.Close()
-
-	found, err := rke2.HasRancherWinsServiceDependency()
-	if err != nil {
-		return fmt.Errorf("error encountered determining rke2 service dependencies: %w", err)
-	}
-
-	if !found && !add {
-		logrus.Info("rke2 service dependency not enabled, nothing to do")
-		return nil
-	}
-
-	if found && add {
-		logrus.Info("rke2 service dependency already configured, nothing to do")
-		return nil
-	}
-
-	if !found && add {
-		logrus.Info("Adding rancher-wins dependency on rke2 service")
-		err = rke2.AddRancherWinsServiceDependency()
-		if err != nil {
-			return fmt.Errorf("error encountered adding rke2 service dependency: %w", err)
-		}
-	}
-
-	if found && !add {
-		logrus.Info("Removing rancher-wins dependency on rke2 service")
-		err = rke2.RemoveRancherWinsServiceDependency()
-		if err != nil {
-			return fmt.Errorf("error encountered adding rke2 service dependency: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// ConfigureWinsDelayedStart opens the rancher-wins service and enables the `DelayedAutoStart` flag.
-// Enabling this flag does not require a restart of the service.
-func ConfigureWinsDelayedStart() error {
-	logrus.Info("Configuring start type for rancher-wins")
-	delayedStart := strings.ToLower(os.Getenv("CATTLE_ENABLE_WINS_DELAYED_START")) == "true"
-
-	wins, exists, err := OpenRancherWinsService()
-	if err != nil {
-		return fmt.Errorf("failed to open %s service while configuring start type: %w", defaults.WindowsServiceName, err)
-	}
-
-	if !exists {
-		logrus.Warnf("could not find the %s service, cannot configure service start type", defaults.WindowsServiceName)
-		return nil
-	}
-
-	defer wins.Close()
-
-	err = wins.ConfigureDelayedStart(delayedStart)
-	if err != nil {
-		return fmt.Errorf("error encountered configuring delayed start for %s service: %w", defaults.WindowsServiceName, err)
-	}
-
-	return nil
-}
 
 // RefreshWinsService restarts the rancher-wins service. If a service dependency has
 // been configured on the rke2 service, the dependency will be temporarily removed and

--- a/suc/pkg/service/service_rancher_wins.go
+++ b/suc/pkg/service/service_rancher_wins.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/rancher/wins/pkg/defaults"
-	"github.com/sirupsen/logrus"
 )
 
 type RancherWinsService struct {
@@ -26,19 +25,4 @@ func OpenRancherWinsService() (*RancherWinsService, bool, error) {
 	}
 
 	return x, exists, nil
-}
-
-func (rw *RancherWinsService) ConfigureDelayedStart(enabled bool) error {
-	logrus.Infof("%s service has delayed auto start configured: %t", defaults.WindowsServiceName, rw.Config.DelayedAutoStart)
-	if rw.Config.DelayedAutoStart != enabled {
-		logrus.Infof("updating %s delayed auto start setting to %t", defaults.WindowsServiceName, enabled)
-		rw.Config.DelayedAutoStart = enabled
-		err := rw.UpdateConfig()
-		if err != nil {
-			return fmt.Errorf("failed to update %s service configuration while configuring service start type: %w", defaults.WindowsServiceName, err)
-		}
-	} else {
-		logrus.Infof("%s delayed start already set to %t, nothing to do", defaults.WindowsServiceName, enabled)
-	}
-	return nil
 }

--- a/suc/pkg/service/state/state.go
+++ b/suc/pkg/service/state/state.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	winsConfig "github.com/rancher/wins/cmd/server/config"
-	"github.com/rancher/wins/pkg/defaults"
 	"github.com/rancher/wins/suc/pkg/service"
 	sucConfig "github.com/rancher/wins/suc/pkg/service/config"
 	"github.com/sirupsen/logrus"
@@ -24,7 +23,6 @@ type InitialState struct {
 }
 
 type Configuration struct {
-	winsDelayedStart bool
 	rke2Dependencies []string
 }
 
@@ -73,7 +71,6 @@ func BuildInitialState() (InitialState, error) {
 	return InitialState{
 		InitialConfig: winsCfg,
 		InitialServiceConfig: Configuration{
-			winsDelayedStart: winsSvc.Config.DelayedAutoStart,
 			rke2Dependencies: rke2Deps,
 		},
 	}, nil
@@ -82,18 +79,6 @@ func BuildInitialState() (InitialState, error) {
 // RestoreInitialState will clear all changes made to the host and reinstate the values contained within InitialState.
 func RestoreInitialState(state InitialState) error {
 	var errs []error
-	// restore rancher-wins service configuration
-	winsSvc, _, err := service.OpenRancherWinsService()
-	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to open %s while restoring initial configuration: %w", defaults.WindowsServiceName, err))
-	}
-
-	if winsSvc.Config.DelayedAutoStart != state.InitialServiceConfig.winsDelayedStart {
-		err = winsSvc.ConfigureDelayedStart(state.InitialServiceConfig.winsDelayedStart)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to revert rancher-wins delayed start to %t: %w", state.InitialServiceConfig.winsDelayedStart, err))
-		}
-	}
 
 	// restore rke2 service configuration
 	saveRke2Config := false

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -244,6 +244,10 @@ function Add-RancherWinsService {
     Log-Info (Get-Service -Name rancher-wins -ErrorAction Ignore)
 }
 
+function Add-RKE2WinsDependency {
+    sc.exe config rke2 depend= rancher-wins
+}
+
 function Get-Permissions {
     param (
         [Parameter(Mandatory=$true)]
@@ -356,3 +360,4 @@ Export-ModuleMember -Function Remove-RancherWinsService
 Export-ModuleMember -Function Get-Permissions
 Export-ModuleMember -Function Test-Permissions
 Export-ModuleMember -Function Ensure-DependencyExistsForService
+Export-ModuleMember -Function Add-RKE2WinsDependency


### PR DESCRIPTION
### Summary

### Issue https://github.com/rancher/rancher/issues/48666

Moving forward, all `v0.4.x` releases of rancher-wins are intended to be used by Rancher <= v2.9.x.

Unfortunately, a feature for Rancher v2.10 and above was included in rancher-wins `v0.4.20`. ideally this would have been tagged at `v0.5.0`. This PR removes the core logic for that feature from the `v0.4` release line, while maintaining some of the enhancements regarding restarting the `rancher-wins` service when set as a dependency on the `rke2` service. 