### PR TITLE
[0.5] `inet.af/tcpproxy` -> `github.com/inetaf/tcpproxy`

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -26,11 +26,16 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
-    
+
     - name: Install Dependencies
       run: |
         go install github.com/magefile/mage@v1.15.0
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
+
+    - name: Build
+      shell: pwsh
+      run: |
+        set PSModulePath=&&powershell -command "mage BuildAll"
 
     - name: Run E2E tests
       shell: pwsh

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/remotedialer v0.4.1
-	github.com/rancher/system-agent v0.3.12-rc.2
+	github.com/rancher/system-agent v0.3.12
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/sync v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc => go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0
 	golang.org/x/oauth2 => golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync => golang.org/x/sync v0.8.0
+	inet.af/tcpproxy => github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c
 	k8s.io/api => k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.32.2
@@ -66,7 +67,7 @@ require (
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 	google.golang.org/grpc v1.69.2
-	inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9
+	inet.af/tcpproxy v0.0.0-20240214030015-3ce58045626c // replaced to github.com/inetaf/tcpproxy
 	k8s.io/api v0.32.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c h1:gYfYE403/nlrGNYj6BEOs9ucLCAGB9gstlSk92DttTg=
+github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c/go.mod h1:Di7LXRyUcnvAcLicFhtM9/MlZl/TNgRSDHORM2c6CMI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
@@ -573,8 +575,6 @@ gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9 h1:zomTWJvjwLbKRgGameQtpK6DNFUbZ2oNJuWhgUkGp3M=
-inet.af/tcpproxy v0.0.0-20231102063150-2862066fc2a9/go.mod h1:Tojt5kmHpDIR2jMojxzZK2w2ZR7OILODmUo2gaSwjrk=
 k8s.io/api v0.32.3 h1:Hw7KqxRusq+6QSplE3NYG4MBxZw1BZnq4aP4cJVINls=
 k8s.io/api v0.32.3/go.mod h1:2wEDTXADtm/HA7CCMD8D8bK4yuBUptzaRhYcYEEYA3k=
 k8s.io/apiextensions-apiserver v0.32.2 h1:2YMk285jWMk2188V2AERy5yDwBYrjgWYggscghPCvV4=

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065 h1:nJPrW/DdnSY
 github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065/go.mod h1:PDAb+l6/i6cbSokQ2CuNCgGOT/BHQY2WgZATwPXEyU4=
 github.com/rancher/remotedialer v0.4.1 h1:jwOf2kPRjBBpSFofv1OuZHWaYHeC9Eb6/XgDvbkoTgc=
 github.com/rancher/remotedialer v0.4.1/go.mod h1:Ys004RpJuTLSm+k4aYUCoFiOOad37ubYev3TkOFg/5w=
-github.com/rancher/system-agent v0.3.12-rc.2 h1:p1YOog5TPNzUMZj9e42mUdZDjXuwdiX/AbJmG6mSSok=
-github.com/rancher/system-agent v0.3.12-rc.2/go.mod h1:4Ew0HpOHnbvg7WmcSBCsVf8yEv3x3JvgXHWvvuDHCH0=
+github.com/rancher/system-agent v0.3.12 h1:WZAZd4HOuPSlij7qyXo6HZ6Ci4kRh2JvWRO4f1QNq1Q=
+github.com/rancher/system-agent v0.3.12/go.mod h1:4Ew0HpOHnbvg7WmcSBCsVf8yEv3x3JvgXHWvvuDHCH0=
 github.com/rancher/wharfie v0.6.7 h1:BhbBVJSLoDQMkZb+zVTLEKckUbq4sc3ZmEYqGakggSY=
 github.com/rancher/wharfie v0.6.7/go.mod h1:ew49A9PzRsTngdzXIkgakfhMq3mHMA650HS1OVQpaNA=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=


### PR DESCRIPTION
### Summary

Replaces the `inet.af/tcpproxy` dependency with the mirrored github repo `github.com/inetaf/tcpproxy`. As explained [in the upstream issue](https://github.com/inetaf/tcpproxy/issues/39), the `.af` TLD is no longer trustworthy and should not be used.  

### Occurred changes and/or fixed issues

Add `inet.af/tcpproxy => github.com/inetaf/tcpproxy v0.0.0-20240214030015-3ce58045626c` to `go.mod`. This also bumps the commit used, however the only new changes present are located in the `README.md` file and `go.mod` file.

Also updated the merge CI for GHA, as it did not match the PR flow and was failing. 

### Technical notes summary

The client proxy package which uses this dependency is not currently used in the rke2 provisioning process, and afaik was only used in rke1 provisioning (which has been EOL for some time now). We may want to consider removing the proxy functionality from wins, since the introduction of host process pods on Windows there isn't much reason to use it within a Kubernetes cluster. 
