### PR TITLE
[main] Fix release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           go install github.com/magefile/mage@v1.15.0
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 
       - name: build-binary
         run: |
@@ -52,7 +52,7 @@ jobs:
         run: ./scripts/build-image.ps1 -NanoServerVersion "ltsc2022" -Repo "${{ env.REPO }}" -Tag "${{ env.TAG }}"
 
       - name: push images
-        run: | 
+        run: |
           docker push ${{ env.REPO }}/wins:${{ env.TAG }}-windows-ltsc2022
 
   create-push-image-windows-2019:
@@ -69,6 +69,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
       - name: retrieve dockerhub credentials
         uses: rancher-eio/read-vault-secrets@main
         with:
@@ -92,7 +93,7 @@ jobs:
       - name: Install Dependencies
         run: |
           go install github.com/magefile/mage@v1.15.0
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 
       - name: build-binary
         run: |
@@ -128,7 +129,7 @@ jobs:
       - name: Install Dependencies
         run: |
           go install github.com/magefile/mage@v1.15.0
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 
       - name: build-binary
         run: |


### PR DESCRIPTION
A recent attempt to release a new rc for v0.5.1 resulted in [CI failures](https://github.com/rancher/wins/actions/runs/14223599350/job/39857537663), specifically errors such as the below are seen 

```
Error: level=error msg="[linters_context] typechecking error: D:\\a\\wins\\wins\\cmd\\cmds\\tools.go:12:29: undefined: cli"
```

This is a similar issue to what was seen in PR CI, which was resolved by bumping `golangci-lint` to a more recent version and removing the standalone github action step. I was able to [reproduce this same error in my personal fork](https://github.com/HarrisonWAffel/wins/actions/runs/14225030450/job/39862388596), and was also able to [confirm this fix in my fork](https://github.com/HarrisonWAffel/wins/actions/runs/14224699009/job/39861249988) ([changes](https://github.com/HarrisonWAffel/wins/commit/78f35ea8a0227ba61ab5bbc5f4dfa52575efad0a)) (the release fails to due missing docker credentials, but the `build-binary` step passes successfully) 