### PR TITLE
2019 GHA Removal

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, windows-latest]
+        platform: [windows-2022]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -40,4 +40,4 @@ jobs:
       run: |
         Install-Module -Name DockerMsftProvider -Force
         Import-Module -Name HostNetworkingService
-        set PSModulePath=&&powershell -command "mage TestAll"
+        set PSModulePath=&&powershell -command "mage ci"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, windows-latest]
+        platform: [windows-2022]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -42,4 +42,4 @@ jobs:
       run: |
         Install-Module -Name DockerMsftProvider -Force
         Import-Module -Name HostNetworkingService
-        set PSModulePath=&&powershell -command "mage TestAll"
+        set PSModulePath=&&powershell -command "mage ci"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,11 +55,8 @@ jobs:
         run: |
           docker push ${{ env.REPO }}/wins:${{ env.TAG }}-windows-ltsc2022
 
-  create-push-image-windows-2019:
-    # Due to limitations on the number of free runners in the Rancher org (20)
-    # we do not build 2019 and 2022 in parallel
-    needs: [create-push-image-windows-2022]
-    runs-on: windows-2019
+  create-push-image-windows-2019-using-2025:
+    runs-on: windows-2025
     env:
       REPO: rancher
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +107,7 @@ jobs:
           docker push ${{ env.REPO }}/wins:${{ env.TAG }}-windows-ltsc2019
 
   create-github-release:
-    needs: [ create-push-image-windows-2019, create-push-image-windows-2022 ]
+    needs: [ create-push-image-windows-2019-using-2025, create-push-image-windows-2022 ]
     runs-on: windows-2022
     permissions:
       contents: write # required for writing release artifacts
@@ -139,7 +136,7 @@ jobs:
         run: gh release create ${{ env.TAG }} --verify-tag --generate-notes .\artifacts\wins.exe .\artifacts\sha256.txt .\artifacts\sha512.txt LICENSE
 
   create-manifest:
-    needs: [ create-push-image-windows-2019, create-push-image-windows-2022 ]
+    needs: [ create-push-image-windows-2019-using-2025, create-push-image-windows-2022 ]
     permissions:
       id-token: write
     env:

--- a/tests/integration/integration_suite_test.ps1
+++ b/tests/integration/integration_suite_test.ps1
@@ -1,12 +1,23 @@
 $ErrorActionPreference = "Stop"
 
 # docker build
-$buildTags = @{ "17763" = "1809"; "20348" = "ltsc2022";}
+$buildTags = @{ "17763" = "1809"; "20348" = "ltsc2022"; "26100" = "2025"}
 $buildNumber = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).CurrentBuildNumber
 $SERVERCORE_VERSION = $buildTags[$buildNumber]
 if (-not $SERVERCORE_VERSION) {
     $SERVERCORE_VERSION = "1809"
 }
+
+# Testing on 2025 is a bit tricky. We're actually only using it to build the 2019 artifacts since 2019 was removed from GHA.
+# So, all of our integration tests expect us to be on 2019. This prevents some test containers from
+# building correctly. Since we don't actually support 2025 yet, there isn't much point running the integration
+# tests anyway. It's also important to note that these integration tests cover functionality that is no longer used
+# by Rancher provisioning, so we aren't losing any relevant test coverage by short circuiting here.
+if ($SERVERCORE_VERSION -eq "2025") {
+    Write-Host "Detected that we are running on Windows 2025. Integration tests are not yet supported on this version. Exiting."
+    exit 0
+}
+
 
 Write-Host "Server core version: $SERVERCORE_VERSION"
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50500

Github is removing support for the Windows 2019 runner on June 30th, but Rancher has not dropped 2019 support. In order to continue supporting Windows provisioning for 2019, the rancher-wins CI needs to be updated to build the 2019 SUC image without using any 2019 runners. This can be done by using Windows 2025, which is able to build 2019 and 2022 images as long as no `RUN` statements are present. 

This PR updates the CI to build 2019 on 2025, as well as short circuits some integration tests from running on 2025. These tests do not cover any functionality currently used by Rancher provisioning, and will still run on 2022, so we aren't losing any relevant test coverage. 

Once this PR is merged it will be backported to 0.4 branch. 

These CI changes were tested locally

Passing PR Run: https://github.com/HarrisonWAffel/wins/actions/runs/15565244883/job/43827602719

Passing Release Run: https://github.com/HarrisonWAffel/wins/actions/runs/15565773859

Produced GH artifacts: https://github.com/HarrisonWAffel/wins/releases/tag/v0.0.0-2025pt2

Produced Docker images: https://hub.docker.com/layers/harrisonwaffel/wins/v0.0.0-2025pt2/images/sha256-113402f6c9b3dcb7f79806aa5ae083dafaa51e096c9b35b06ad44c9506e1347e

Finally, I provisioned a Windows cluster using a single Windows 2019 datacenter VM and confirmed that the SUC image deployed and executed properly. 