### PR TITLE
fix: Properly handle certificate chains in install.ps1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/remotedialer v0.5.0
-	github.com/rancher/system-agent v0.3.13
+	github.com/rancher/system-agent v0.3.14-rc.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/sync v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065 h1:nJPrW/DdnSY
 github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065/go.mod h1:PDAb+l6/i6cbSokQ2CuNCgGOT/BHQY2WgZATwPXEyU4=
 github.com/rancher/remotedialer v0.5.0 h1:4H1o9ZBdA1nboaMPBvy03EQlFWXXzwcdMAXLmafop54=
 github.com/rancher/remotedialer v0.5.0/go.mod h1:hpx8oaoxXyy8yHMWH5Iv8GcdVlYEYYzgVNjeXZrhv8E=
-github.com/rancher/system-agent v0.3.13 h1:U7KDWo0IPYmL3SNhC9vPUxpjmz/q4G/e41T93eQP1ao=
-github.com/rancher/system-agent v0.3.13/go.mod h1:nLanHUc0SqPj5zz3mpJi0QLX3mPno15/HpSpZeY9ITU=
+github.com/rancher/system-agent v0.3.14-rc.1 h1:0AqXA57Zx5LoYtmlT5idA2/T5NILxFcigeuJNtOp690=
+github.com/rancher/system-agent v0.3.14-rc.1/go.mod h1:tlifPi81Qq5F/Ki1Kv9dVWPrJG65QZVhsskUR4YEcQw=
 github.com/rancher/wharfie v0.7.0 h1:M+OHMkE+tfafY59E5RuZ/Q4IorKNJGVqhtZRksTpOWo=
 github.com/rancher/wharfie v0.7.0/go.mod h1:wSQoRNUM58z0Qb9kmAT1L6ia2ys0LWHRH+7Vix/rkD8=
 github.com/rancher/wrangler/v3 v3.2.2 h1:IK1/v8n8gaZSB4izmJhGFXJt38Z8gkbwzl3Lo/e2jQc=

--- a/install.ps1
+++ b/install.ps1
@@ -443,14 +443,18 @@ function Invoke-WinsInstaller {
         # Import-Certificate does not automatically handle chains included in a single file,
         # so we need to manually extract and import each certificate into the Root store.
         Write-LogInfo "Detected certificate chain"
+
+        $collection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+        ForEach($cert in $allCerts) {
+            Write-LogInfo "Adding a certificate entry from the provided chain to the collection..."
+            $x5092 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new([System.Text.Encoding]::UTF8.GetBytes($cert))
+            $collection.Add($x5092)
+        }
+
         $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new([System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
         $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::MaxAllowed)
-        ForEach($cert in $allCerts) {
-            Write-LogInfo "Importing a certificate entry from the provided chain..."
-            $encodedCert = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cert))
-            $x509 = [X509Certificate]::new([convert]::FromBase64String($encodedCert))
-            $certStore.Add($x509)
-        }
+        Write-LogInfo "Adding collection to certificate store"
+        $certStore.AddRange($collection)
         $certStore.Close()
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -540,7 +540,7 @@ function Invoke-WinsInstaller {
 
     function Set-WinsConfig() {
         $winsConfig =
-        @"
+@"
 white_list:
   processPaths:
     - $($env:CATTLE_AGENT_CONFIG_DIR)/powershell.exe
@@ -553,7 +553,7 @@ white_list:
         Set-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $winsConfig
 
         $agentConfig = 
-        @"
+@"
 agentStrictTLSMode: $(($env:STRICT_VERIFY).ToString().ToLower())
 systemagent:
   workDirectory: $($env:CATTLE_AGENT_VAR_DIR)/work
@@ -568,9 +568,9 @@ systemagent:
         }
         if ((Test-Path -Path $env:RANCHER_CERT) -and ($env:CA_REQUIRED -eq "true")) {
             $tlsConfig =
-            @"
-            tls-config:
-                certFilePath: $($($env:RANCHER_CERT).Replace("\\","/"))
+@"
+tls-config:
+  certFilePath: $($($env:RANCHER_CERT).Replace("\\","/"))
 "@
             Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $tlsConfig
         }
@@ -579,7 +579,7 @@ systemagent:
 
     function Set-CsiProxyConfig() {
         $proxyConfig = 
-        @"
+@"
 csi-proxy:
   url: $($env:CSI_PROXY_URL)
   version: $($env:CSI_PROXY_VERSION)

--- a/pkg/csiproxy/csi.go
+++ b/pkg/csiproxy/csi.go
@@ -138,7 +138,7 @@ func (p *Proxy) download() error {
 	// as long as the req does not match an entry in no_proxy env var
 	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, Proxy: http.ProxyFromEnvironment}
 
-	if p.tlsCfg != nil && !*p.tlsCfg.Insecure && p.tlsCfg.CertFilePath != "" {
+	if p.tlsCfg != nil && p.tlsCfg.Insecure != nil && !*p.tlsCfg.Insecure && p.tlsCfg.CertFilePath != "" {
 		transport.TLSClientConfig.InsecureSkipVerify = false
 	}
 

--- a/tests/integration/install_certs_test.ps1
+++ b/tests/integration/install_certs_test.ps1
@@ -1,0 +1,189 @@
+$ErrorActionPreference = "Stop"
+
+Import-Module -Name @(
+    "$PSScriptRoot\utils.psm1"
+) -WarningAction Ignore
+
+$StartMockRancherHandler = {
+    param(
+        [Parameter()]
+        [string]
+        $certs
+    )
+
+    $http = New-Object System.Net.HttpListener
+    $http.Prefixes.Add("http://localhost:8080/")
+    $http.Start()
+
+    while($http.IsListening) {
+        $ctx = $http.GetContext()
+        if ($ctx.Request.RawUrl -eq "/cacerts") {
+            $buf = [System.Text.Encoding]::UTF8.GetBytes($certs)
+            $ctx.response.ContentLength64 = $buf.Length
+            $ctx.Response.OutputStream.Write($buf, 0, $buf.Length)
+            $ctx.Response.OutputStream.Close()
+        }
+        # A dedicated kill endpoint works around a deadlock
+        # that is encountered when Stop-Job is invoked at the same itme
+        # that this function is waiting on GetContext()
+        if ($ctx.Request.RawUrl -eq "/kill") {
+            $ctx.Response.OutputStream.Close()
+            exit 0
+        }
+    }
+}
+
+Describe "Install script certificate tests" {
+    BeforeEach {
+        # Create a test specific copy of the install script
+        # as the environment variables being set may differ between tests
+        Copy-Item install.ps1 install-certs-test.ps1 -Force
+
+        # note: Simply running the install script does not do anything. During normal provisioning,
+        # Rancher will mutate the install script to both add environment variables, and to call
+        # the primary function 'Invoke-WinsInstaller'. As this is an integration test, we need to manually
+        # update the install script ourselves.
+        Add-Content -Path ./install-certs-test.ps1 -Value '$env:CATTLE_REMOTE_ENABLED = "false"'
+        Add-Content -Path ./install-certs-test.ps1 -Value '$env:CATTLE_LOCAL_ENABLED = "true"'
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_SERVER = `"http://localhost:8080`""
+        # reset the agent directory
+        Remove-Item "C:/etc/rancher/wins" -Force -ErrorAction Ignore
+    }
+
+    AfterEach {
+        Cleanup-CertFile
+        $env:CATTLE_CA_CHECKSUM = ""
+        $env:CATTLE_SERVER = ""
+        Log-Info "Running uninstall script"
+        try {
+            # note: since this script may not be run by an administrator, it's possible that it might fail
+            # on trying to delete certain files with ACLs attached to them.
+            # If you are running this locally, make sure you run with admin privileges.
+            .\uninstall.ps1
+        } catch {
+            Log-Warn "You need to manually run uninstall.ps1, encountered error: $($_.Exception.Message)"
+        }
+    }
+
+    It "Imports a single cert properly" {
+        Log-Info "TEST: [Imports a single cert properly]"
+        $expectedCertificates = 1
+        $certData = Setup-CertFiles -length $expectedCertificates
+        $certData.ThumbPrints.Length | Should -BeExactly $expectedCertificates
+
+        # Quick sanity check to ensure utility function properly removed
+        # certificates from the built-in stores
+        Log-Info "Ensuring that certs are not yet imported"
+        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new([System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
+        $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::MaxAllowed)
+        foreach ($thumbPrint in $certData.ThumbPrints)
+        {
+            Log-Info "Ensuring cert with thumb print of $thumbPrint is not imported yet"
+            $found = $certStore.Certificates.Find('FindByThumbprint', $thumbPrint, $false)
+            $found.Count | Should -Be -ExpectedValue 0
+            Log-Info "Confirmed that cert with thumb print of $thumbPrint has not been imported yet"
+        }
+
+        $checkSum = $certData.Checksum
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        Log-Info "Starting mock Rancher API"
+        $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $certData.FinalCertBlocks
+        Start-Sleep 1
+        if ($job.State -ne "Running") {
+            # display job output to help debug job failure
+            Log-Error "Mock Rancher server failed to start"
+            $job | Receive-Job
+            $job.State | Should -Be -ExpectedValue "Running"
+        }
+
+        Log-Info "Invoking install script function"
+        .\install-certs-test.ps1
+        $installScriptExitCode = $LASTEXITCODE
+
+        Log-Info "Stopping mock server"
+        curl.exe -sS http://localhost:8080/kill
+        Remove-Job -Id $job.Id -Force
+
+        Log-Info "Install script exited with code $installScriptExitCode"
+        $installScriptExitCode | Should -Be -ExpectedValue 0
+
+        Log-Info "Confirming that certs have been properly imported..."
+        foreach ($thumbPrint in $certData.ThumbPrints)
+        {
+            Log-Info "Checking cert with thumb print of $thumbPrint"
+            $found = $certStore.Certificates.Find('FindByThumbprint', $thumbPrint, $false)
+            if ($found.Count -ne 1)
+            {
+                Log-Error "Could not find cert with thumbprint of $thumbPrint"
+                $found.Count | Should -Be -ExpectedValue 1
+            }
+            Log-Info "Found $thumbPrint"
+        }
+
+        $certStore.Close()
+        Log-Info "Properly imported $expectedCertificates certificates"
+    }
+
+    It "Imports a chain properly" {
+        Log-Info "TEST: [Imports a chain properly]"
+        $expectedCertificates = 3
+        $certData = Setup-CertFiles -length $expectedCertificates
+        $certData.ThumbPrints.Length | Should -BeExactly $expectedCertificates
+
+        # Quick sanity check to ensure utility function properly removed
+        # certificates from the built-in stores
+        Log-Info "Ensuring that certs are not yet imported"
+
+        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new([System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
+        $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::MaxAllowed)
+        foreach ($thumbPrint in $certData.ThumbPrints)
+        {
+            Log-Info "Ensuring cert with thumb print of $thumbPrint is not imported yet"
+            $found = $certStore.Certificates.Find('FindByThumbprint', $thumbPrint, $false)
+            $found.Count | Should -Be -ExpectedValue 0
+        }
+
+        $checkSum = $certData.Checksum
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        Log-Info "Starting mock Rancher API"
+        $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $certData.FinalCertBlocks
+        Start-Sleep 1
+        if ($job.State -ne "Running") {
+            # display job output to help debug job failure
+            Log-Error "Mock Rancher server failed to start"
+            $job | Receive-Job
+            $job.State | Should -Be -ExpectedValue "Running"
+        }
+
+        Log-Info "Invoking install script"
+        .\install-certs-test.ps1
+        $installScriptExitCode = $LASTEXITCODE
+
+        Log-Info "Stopping mock server"
+        curl.exe -sS http://localhost:8080/kill
+        Remove-Job -Id $job.Id -Force
+
+        Log-Info "Install script exited with code $installScriptExitCode"
+        $installScriptExitCode | Should -Be -ExpectedValue 0
+
+        Log-Info "Confirming that certs have been properly imported..."
+        foreach ($thumbPrint in $certData.ThumbPrints)
+        {
+            Log-Info "Confirming that cert with thumb print of $thumbPrint has been imported"
+            $found = $certStore.Certificates.Find('FindByThumbprint', $thumbPrint, $false)
+            if ($found.Count -ne 1)
+            {
+                Log-Error "Did not find cert with thumb print of: $thumbPrint"
+                $found.Count | Should -Be -ExpectedValue 1
+            }
+            Log-Info "Cert with thumbprint of $thumbPrint was properly imported"
+        }
+
+        $certStore.Close()
+        Log-Info "Properly imported $expectedCertificates certificates"
+    }
+}

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -349,6 +349,138 @@ function Get-LatestCommitOrTag {
     return $(git rev-parse --short HEAD)
 }
 
+function Cleanup-CertFile() {
+    $path = "$PSScriptRoot\testcert.pem"
+    Remove-Item -Path $path -Force -ErrorAction Ignore
+}
+
+function Setup-CertFiles() {
+    param (
+        [Parameter()]
+        [int]
+        $length
+    )
+
+    $certFilePath = "$PSScriptRoot\testcert.pem"
+
+    Log-Info "Generating $length certificates"
+
+    $root = New-SelfSignedCertificate -Subject "CN=wins-test-root-CA" -KeyUsage CertSign, CRLSign -KeyAlgorithm RSA -KeyLength 2048 -NotAfter (Get-Date).AddYears(1)
+    if ($null -eq $root) {
+        Log-Info "Failed to generate root certificate"
+        exit 1
+    }
+
+    Log-Info "Generated root CA certificate"
+
+    [System.Security.Cryptography.X509Certificates.X509Certificate2[]]$certChain = @()
+    $certChain += ($root)
+    # Subtract 1 since we always include the root CA
+    for ($i = 0; $i -lt $length-1; $i++) {
+        if ($i -eq $length - 2) {
+            $cert = newCert -parentCerts $certChain -isLeaf
+            if ($null -ne $cert)
+            {
+                $certChain += ($cert)
+            }
+        } else
+        {
+            $cert = newCert -parentCerts $certChain -isIntermediate
+            if ($null -ne $cert)
+            {
+                $certChain += ($cert)
+            }
+        }
+    }
+
+    $finalCertFile = ""
+    Log-Info "Generated $length certificates"
+    foreach ($cert in $certChain) {
+        $block = getCertString -cert $cert
+        $finalCertFile = $finalCertFile.Trim() + "`n" + $block.Trim()
+    }
+
+    # write final cert file to disk to generate a hash
+    Set-Content -NoNewline -Path $certFilePath -Value $finalCertFile
+
+    $thumbPrints = @()
+
+    Log-Info "Removing all generated certs from local cert store"
+    foreach ($cert in $certChain) {
+        $thumbPrints += @($cert.Thumbprint)
+        Remove-Item -Path $cert.PSPath -DeleteKey
+    }
+
+    Log-Info "Deleted all certs from cert stores"
+    $shasum = (Get-FileHash -Path $certFilePath -Algorithm SHA256).Hash.ToLower()
+    Log-Info "Computed sha256 sum of the final cert file is: $shasum"
+
+    return [PSCustomObject]@{
+        FinalCertBlocks = $finalCertFile
+        ThumbPrints = $thumbPrints
+        Checksum = $shasum
+    }
+}
+
+function getCertString() {
+    param (
+        [Parameter()]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]
+        $cert
+    )
+
+    if ($cert -eq $null) {
+        Log-Error "a null cert was provided to getCertString"
+        exit 1
+    }
+
+    $base64Content = [System.Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks')
+    $newBlock = @"
+-----BEGIN CERTIFICATE-----
+$base64Content
+-----END CERTIFICATE-----
+"@
+
+    return $newBlock
+}
+
+function newCert() {
+    param (
+        [Parameter()]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2[]]
+        $parentCerts,
+
+        [Parameter()]
+        [Switch]
+        $isLeaf,
+
+        [Parameter()]
+        [Switch]
+        $isIntermediate
+    )
+
+    if ($isLeaf -and $isIntermediate) {
+        Log-Error "a cert cannot be both a leaf and an intermediate"
+        return
+    }
+
+    if ($isLeaf) {
+        Log-Info "Creating a new leaf certificate"
+        $cert = New-SelfSignedCertificate -Subject "CN=wins-test-leaf-cert" -DnsName "wins.com" -Signer $parentCerts[-1] -KeyAlgorithm RSA -KeyLength 2048 -NotAfter (Get-Date).AddYears(1)
+        return $cert
+    }
+
+    if ($isIntermediate) {
+        Log-Info "Creating a new intermediate certificate"
+        $cert = New-SelfSignedCertificate -Subject "CN=wins-test-intermediate-cert" -KeyUsage CertSign, CRLSign -Signer $parentCerts[-1] -KeyAlgorithm RSA -KeyLength 2048 -NotAfter (Get-Date).AddYears(1)
+        return $cert
+    }
+
+    return $null
+}
+
+Export-ModuleMember -Function Setup-CertFiles
+Export-ModuleMember -Function Cleanup-CertFile
 Export-ModuleMember -Function Log-Info
 Export-ModuleMember -Function Log-Warn
 Export-ModuleMember -Function Log-Error


### PR DESCRIPTION
### Summary
<!-- Add a link to a tracking GitHub issue, typically located in rancher/rancher -->
Issue: https://github.com/rancher/rancher/issues/47758

During node registration `install.ps1` will contact the local Rancher server `/cacerts` endpoint so that it can add any custom CA and intermediate certificates into the Windows certificate store. Importing the certificates into the Windows store ensures that all applications on the host can properly communicate with the Rancher server, and is required for the later portions of `install.ps1` to function as expected.

Currently, the install script simply runs `Import-Certificate` against a file containing the response body of the `/cacerts` endpoint. Unfortunately, `Import-Certificate` will only ever import a single certificate, even if multiple are included in the provided file. Due to this, Windows nodes do not properly handle private certificate chains returned from the `/cacerts` endpoint.

Additionally, this PR fixes formatting issues when setting the `tlsConfig` in the wins config file, as well as prevents a null pointer error when deploying the csi proxy. 

### Occurred changes and/or fixed issues
Implement a new function, `Import-Certificates` which properly imports both single certificates and certificate chains.

A regular expression both identifies certificate chains as well as breaks up individual blocks so that they can be imported one at a time.  

### Technical notes summary

I've added some integration tests to cover this scenario, as well as updated an existing test to play nicely with the new ones

### Areas or cases that should be tested

I have stood up a HA Rancher server and configured it to use a custom root CA, an intermediate CA, and a leaf certificate signed by the intermediate CA. I confirmed that registering a Windows node to a custom cluster works when the updated `install.ps1` script is used, and that the windows certificate store includes both certificates.

I also confirmed that the wins config file now properly formats the `tlsConfig` field. 

### Areas or cases to be tested

Registering a Custom or Node Driver provisioned Windows node against a Rancher server which provides more than one certificate in the `/cacerts` endpoint

1. `/cacerts` returns a single root CA certificate for the Rancher hostname 
2. `/cacerts` returns a root CA certificate and an intermediate certificate
3. `/cacerts` returns a root CA certificate and multiple intermediate certificates

### Areas which could experience regressions
Rancher installs which only provide a single certificate in the `/cacerts` endpoint
