### PR TITLE
chore: Improve CI runtime by disabling caching

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
+
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -24,6 +25,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
+        cache: 'false'
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
+        cache: 'false'
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+          cache: 'false'
 
       - name: Install Dependencies
         run: |
@@ -86,6 +87,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+          cache: 'false'
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
### Summary

CI installs Go using the `actions/setup-go` action, in order to run the mage steps included in `magefiles/magefile.go`. 
Occasionally, this process [can take several minutes to complete](https://github.com/rancher/wins/actions/runs/16186343376/job/45692638881?pr=276#step:3:1), unnecessarily increasing CI run time. This is due to the action using the `C:\` drive by default to load previous installations from cache.

In GHA runners, the `C:\` has very poor performance. It turns out to be faster to simply disable caching, and just always download Go. Caching isn't useful in this repo due to how infrequently actions are run - it's unlikely we will hit a request limit. 

This is really a workaround to an upstream issue, which is being tracked [here](https://github.com/actions/setup-go/issues/495).

### Occurred changes and/or fixed issues
Add `cache: 'false'` to all uses of the `setup-go` action

### Technical notes summary

I tested this in my local fork and confirmed that the step [consistently completed](https://github.com/HarrisonWAffel/wins/actions/runs/16328847312?pr=19) in  ~ 20 - 40 seconds (ignore the flakey test runs)

### Additional notes

I've tried getting `mage` to work without using the `setup-go` action, but have not had luck. Looking at the official mage action, it seems that `setup-go` is [a requirement](https://github.com/magefile/mage-action#quick-start). 