### PR TITLE
Uninstall script improvements

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,13 +20,14 @@
       - CATTLE_LABELS
       - CATTLE_TAINTS
       Advanced Environment Variables
-      - CATTLE_AGENT_BINARY_URL (default: latest GitHub release)
+      - CATTLE_AGENT_BINARY_URL (default: pinned GitHub release)
       - CATTLE_PRESERVE_WORKDIR (default: false)
       - CATTLE_REMOTE_ENABLED (default: true)
       - CATTLE_LOCAL_ENABLED (default: false)
       - CATTLE_ID (default: autogenerate)
       - CATTLE_AGENT_BINARY_LOCAL (default: false)
       - CATTLE_AGENT_BINARY_LOCAL_LOCATION (default: )
+      - CATTLE_AGENT_BINARY_CHECKSUM (default: hardcoded fallback checksum)
       - CSI_PROXY_URL (default: )
       - CSI_PROXY_VERSION (default: )
       - CSI_PROXY_KUBELET_PATH (default: )
@@ -73,6 +74,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $FALLBACK = "v0.4.15"
+$FALLBACK_BINARY_SUM = "8bb68f9e3d92ac08be66cb5fbe6d1dce5c4460b26e0b033e58fece21ce9a8680"
 
 function Invoke-WinsInstaller {
     [CmdletBinding()]
@@ -139,6 +141,19 @@ function Invoke-WinsInstaller {
         $writer.Flush()
         $stringAsStream.Position = 0
         return (Get-FileHash -InputStream $stringAsStream -Algorithm SHA256).Hash.ToLower()
+    }
+
+    function Set-FallbackVersion {
+        param (
+            [Parameter(Mandatory=$true)]
+            [string]
+            $Reason
+        )
+        Write-LogInfo $Reason
+        $env:VERSION = $FALLBACK
+        if (-Not $env:CATTLE_AGENT_BINARY_CHECKSUM) {
+            $env:CATTLE_AGENT_BINARY_CHECKSUM = $FALLBACK_BINARY_SUM
+        }
     }
 
     function Get-Args {
@@ -268,22 +283,7 @@ function Invoke-WinsInstaller {
             }
 
             if (-Not $env:CATTLE_AGENT_BINARY_URL) {
-                $rateLimit = $(curl.exe --connect-timeout 60 --max-time 300 $env:CURL_CAFLAG -sfL "https://api.github.com/rate_limit") | ConvertFrom-Json
-               
-                if ($rateLimit.rate.remaining -eq 0) {
-                    Write-LogInfo "Error contacting GitHub to retrieve the latest version, falling back to version: $FALLBACK"
-                    $env:VERSION = $FALLBACK
-                }
-                else {
-                    try {
-                        $env:VERSION = $(curl.exe --connect-timeout 60 $env:CURL_CAFLAG -sfL "https://api.github.com/repos/rancher/wins/releases/latest" | ConvertFrom-Json).tag_name
-                    }
-                    catch {
-                        Write-LogInfo "Error contacting GitHub to retrieve the latest version, falling back to version: $FALLBACK"
-                        $env:VERSION = $FALLBACK
-                    }
-                }
-
+                Set-FallbackVersion "Using pinned fallback version ${FALLBACK} for the default upstream agent binary"
                 $env:CATTLE_AGENT_BINARY_URL = "https://github.com/rancher/wins/releases/download/$env:VERSION/wins.exe"
                 $env:BINARY_SOURCE = "upstream"
             }
@@ -381,6 +381,15 @@ function Invoke-WinsInstaller {
         }
         if (-Not (Test-Path "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe")) {
             Write-LogFatal "Wins.exe doesn't appear to have been installed."
+        }
+
+        if ($env:CATTLE_AGENT_BINARY_CHECKSUM) {
+            Write-LogInfo "Verifying checksum for wins.exe"
+            $actual = (Get-FileHash -Path "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe" -Algorithm SHA256).Hash.ToLower()
+            if ($actual -ne $env:CATTLE_AGENT_BINARY_CHECKSUM.ToLower()) {
+                Write-LogFatal "Checksum validation failed for wins.exe.`n  Expected: $($env:CATTLE_AGENT_BINARY_CHECKSUM)`n  Got:      $actual"
+            }
+            Write-LogInfo "Checksum verification passed for wins.exe"
         }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -78,7 +78,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $FALLBACK = "v0.5.4"
-$FALLBACK_BINARY_SUM = "sha256:8fab9744af8f089a3cd7bea4fd3c70ec71842da80d8e1994f843a884026fd710"
+$FALLBACK_BINARY_SUM = "8fab9744af8f089a3cd7bea4fd3c70ec71842da80d8e1994f843a884026fd710"
 $FALLBACK_UNINSTALL_SUM  = "bcc0f990176079f7dc69e668907230ac785d4676e037eef5b70cf3316e614adc"
 
 function Invoke-WinsInstaller {
@@ -417,20 +417,15 @@ function Invoke-WinsInstaller {
 
             $retries = 0
             while ($retries -lt 6) {
-                $responseCode = $(curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" $env:CURL_BIN_CAFLAG -sfL $Url -o $DestinationPath)
+                $responseCode = curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}" $env:CURL_BIN_CAFLAG -sL $Url -o $DestinationPath
 
-                switch ($responseCode) {
-                    { $_ -in "ok200", 200 } {
-                        Write-LogInfo "Successfully downloaded $Name."
-                        $retries = 99
-                        break
-                    }
-                    default {
-                        Write-LogError "$responseCode received while downloading $Name. Sleeping for 5 seconds and trying again."
-                        Start-Sleep -Seconds 5
-                        $retries++
-                        continue
-                    }
+                if ($responseCode -eq "200") {
+                    Write-LogInfo "Successfully downloaded $Name."
+                    break
+                } else {
+                    Write-LogError "$responseCode received while downloading $Name. Sleeping for 5 seconds and trying again."
+                    Start-Sleep -Seconds 5
+                    $retries++
                 }
             }
         }

--- a/install.ps1
+++ b/install.ps1
@@ -438,7 +438,7 @@ function Invoke-WinsInstaller {
             Write-LogInfo "Verifying checksum for $Name"
             $actual = (Get-FileHash -Path $DestinationPath -Algorithm SHA256).Hash.ToLower()
             if ($actual -ne $Checksum.ToLower()) {
-                Write-LogFatal "Checksum validation failed for $Name.`n  Expected: $Checksum`n  Got:      $actual"
+                Write-LogFatal "Checksum validation failed for $Name"
             }
             Write-LogInfo "Checksum verification passed for $Name"
         }

--- a/install.ps1
+++ b/install.ps1
@@ -21,6 +21,7 @@
       - CATTLE_TAINTS
       Advanced Environment Variables
       - CATTLE_AGENT_BINARY_URL (default: pinned GitHub release)
+      - CATTLE_AGENT_UNINSTALL_URL (default: pinned GitHub release)
       - CATTLE_PRESERVE_WORKDIR (default: false)
       - CATTLE_REMOTE_ENABLED (default: true)
       - CATTLE_LOCAL_ENABLED (default: false)
@@ -28,6 +29,9 @@
       - CATTLE_AGENT_BINARY_LOCAL (default: false)
       - CATTLE_AGENT_BINARY_LOCAL_LOCATION (default: )
       - CATTLE_AGENT_BINARY_CHECKSUM (default: hardcoded fallback checksum)
+      - CATTLE_AGENT_UNINSTALL_LOCAL (default: false)
+      - CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION (default: )
+      - CATTLE_AGENT_UNINSTALL_CHECKSUM (default: hardcoded fallback checksum)
       - CSI_PROXY_URL (default: )
       - CSI_PROXY_VERSION (default: )
       - CSI_PROXY_KUBELET_PATH (default: )
@@ -73,8 +77,9 @@ param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$FALLBACK = "v0.4.15"
-$FALLBACK_BINARY_SUM = "8bb68f9e3d92ac08be66cb5fbe6d1dce5c4460b26e0b033e58fece21ce9a8680"
+$FALLBACK = "v0.5.4"
+$FALLBACK_BINARY_SUM = "sha256:8fab9744af8f089a3cd7bea4fd3c70ec71842da80d8e1994f843a884026fd710"
+$FALLBACK_UNINSTALL_SUM  = "bcc0f990176079f7dc69e668907230ac785d4676e037eef5b70cf3316e614adc"
 
 function Invoke-WinsInstaller {
     [CmdletBinding()]
@@ -153,6 +158,9 @@ function Invoke-WinsInstaller {
         $env:VERSION = $FALLBACK
         if (-Not $env:CATTLE_AGENT_BINARY_CHECKSUM) {
             $env:CATTLE_AGENT_BINARY_CHECKSUM = $FALLBACK_BINARY_SUM
+        }
+        if (-Not $env:CATTLE_AGENT_UNINSTALL_CHECKSUM) {
+            $env:CATTLE_AGENT_UNINSTALL_CHECKSUM = $FALLBACK_UNINSTALL_SUM
         }
     }
 
@@ -289,6 +297,29 @@ function Invoke-WinsInstaller {
             }
         }
 
+        if ($env:CATTLE_AGENT_UNINSTALL_LOCAL -eq "true") {
+            if (-Not $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION) {
+                Write-LogFatal "No local uninstall location was specified"
+            }
+            Write-LogInfo "Using local uninstall script from $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION"
+            $env:UNINSTALL_SOURCE = "local"
+        }
+        else {
+            $env:UNINSTALL_SOURCE = "remote"
+            if (-Not $env:CATTLE_AGENT_UNINSTALL_URL -and $env:CATTLE_AGENT_BINARY_BASE_URL) {
+                $env:CATTLE_AGENT_UNINSTALL_URL = "$env:CATTLE_AGENT_BINARY_BASE_URL/wins-agent-uninstall.ps1"
+            }
+
+            if (-Not $env:CATTLE_AGENT_UNINSTALL_URL) {
+                if ($env:VERSION) {
+                    Write-LogInfo "Version $env:VERSION used for downloading the wins binary, will reuse for uninstall script"
+                }
+                Set-FallbackVersion "Using pinned fallback version ${FALLBACK} for the default upstream agent uninstall script."
+                $env:CATTLE_AGENT_UNINSTALL_URL = "https://raw.githubusercontent.com/rancher/wins/refs/tags/$env:VERSION/uninstall.ps1"
+                $env:UNINSTALL_SOURCE = "upstream"
+            }
+        }
+
         if ($env:CATTLE_REMOTE_ENABLED -eq "true") {
             if (-Not $env:CATTLE_TOKEN) {
                 Write-LogFatal "Environment variable CATTLE_TOKEN was not set. Will not retrieve a remote connection configuration from Rancher2"
@@ -342,36 +373,61 @@ function Invoke-WinsInstaller {
         }
     }
 
-    function Invoke-WinsAgentDownload() {
-        if (-Not (Test-Path "$env:CATTLE_AGENT_BIN_PREFIX/bin")) {
-            New-Item -Path "$env:CATTLE_AGENT_BIN_PREFIX/bin" -ItemType Directory -Force | Out-Null
+    function Invoke-RancherFileDownload {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            [string]
+            $Name,            # human-readable name for log messages, e.g. "wins binary"
+
+            [Parameter(Mandatory=$true)]
+            [string]
+            $DestinationPath, # full destination file path
+
+            [Parameter(Mandatory=$true)]
+            [string]
+            $Source,          # "local", "remote", or "upstream"
+
+            [Parameter(Mandatory=$false)]
+            [string]
+            $Url,             # download URL (required when Source != "local")
+
+            [Parameter(Mandatory=$false)]
+            [string]
+            $LocalPath,       # source path (required when Source == "local")
+
+            [Parameter(Mandatory=$false)]
+            [string]
+            $Checksum         # expected SHA256 (optional; always verified when provided)
+        )
+
+        if (-Not (Test-Path (Split-Path $DestinationPath))) {
+            New-Item -Path (Split-Path $DestinationPath) -ItemType Directory -Force | Out-Null
         }
-        
-        if ($env:CATTLE_AGENT_BINARY_LOCAL -eq "true") {
-            Write-LogInfo "Using local Wins installer from $($env:CATTLE_AGENT_BINARY_LOCAL_LOCATION)"
-            Copy-Item -Path $env:CATTLE_AGENT_BINARY_LOCAL_LOCATION -Destination "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe"
+
+        if ($Source -eq "local") {
+            Write-LogInfo "Using local $Name from $LocalPath"
+            Copy-Item -Path $LocalPath -Destination $DestinationPath -Force
         }
         else {
-            Write-LogInfo "Downloading Wins from $($env:CATTLE_AGENT_BINARY_URL)"
+            Write-LogInfo "Downloading $Name from $Url"
+            $env:CURL_BIN_CAFLAG = ""
             if ($env:BINARY_SOURCE -ne "upstream") {
                 $env:CURL_BIN_CAFLAG = $env:CURL_CAFLAG
             }
-            else {
-                $env:CURL_BIN_CAFLAG = ""
-            }
 
-            $retries = 0  
+            $retries = 0
             while ($retries -lt 6) {
-                $responseCode = $(curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" $env:CURL_BIN_CAFLAG -sfL "$($env:CATTLE_AGENT_BINARY_URL)" -o "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe")
-                
-                switch ( $responseCode ) {
-                    { "ok200", 200 } {
-                        Write-LogInfo "Successfully downloaded the wins binary." 
+                $responseCode = $(curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" $env:CURL_BIN_CAFLAG -sfL $Url -o $DestinationPath)
+
+                switch ($responseCode) {
+                    { $_ -in "ok200", 200 } {
+                        Write-LogInfo "Successfully downloaded $Name."
                         $retries = 99
                         break
                     }
                     default {
-                        Write-LogError "$responseCode received while downloading the wins binary. Sleeping for 5 seconds and trying again." 
+                        Write-LogError "$responseCode received while downloading $Name. Sleeping for 5 seconds and trying again."
                         Start-Sleep -Seconds 5
                         $retries++
                         continue
@@ -379,18 +435,39 @@ function Invoke-WinsInstaller {
                 }
             }
         }
-        if (-Not (Test-Path "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe")) {
-            Write-LogFatal "Wins.exe doesn't appear to have been installed."
+
+        if (-Not (Test-Path $DestinationPath)) {
+            Write-LogFatal "$Name doesn't appear to have been installed at $DestinationPath"
         }
 
-        if ($env:CATTLE_AGENT_BINARY_CHECKSUM) {
-            Write-LogInfo "Verifying checksum for wins.exe"
-            $actual = (Get-FileHash -Path "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe" -Algorithm SHA256).Hash.ToLower()
-            if ($actual -ne $env:CATTLE_AGENT_BINARY_CHECKSUM.ToLower()) {
-                Write-LogFatal "Checksum validation failed for wins.exe.`n  Expected: $($env:CATTLE_AGENT_BINARY_CHECKSUM)`n  Got:      $actual"
+        if ($Checksum) {
+            Write-LogInfo "Verifying checksum for $Name"
+            $actual = (Get-FileHash -Path $DestinationPath -Algorithm SHA256).Hash.ToLower()
+            if ($actual -ne $Checksum.ToLower()) {
+                Write-LogFatal "Checksum validation failed for $Name.`n  Expected: $Checksum`n  Got:      $actual"
             }
-            Write-LogInfo "Checksum verification passed for wins.exe"
+            Write-LogInfo "Checksum verification passed for $Name"
         }
+    }
+
+    function Invoke-WinsAgentDownload {
+        Invoke-RancherFileDownload `
+            -Name            "wins binary" `
+            -DestinationPath "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe" `
+            -Source          $env:BINARY_SOURCE `
+            -Url             $env:CATTLE_AGENT_BINARY_URL `
+            -LocalPath       $env:CATTLE_AGENT_BINARY_LOCAL_LOCATION `
+            -Checksum        $env:CATTLE_AGENT_BINARY_CHECKSUM
+    }
+
+    function Invoke-WinsUninstallScriptDownload {
+        Invoke-RancherFileDownload `
+            -Name            "uninstall script" `
+            -DestinationPath "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins-agent-uninstall.ps1" `
+            -Source          $env:UNINSTALL_SOURCE `
+            -Url             $env:CATTLE_AGENT_UNINSTALL_URL `
+            -LocalPath       $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION `
+            -Checksum        $env:CATTLE_AGENT_UNINSTALL_CHECKSUM
     }
 
     function Test-CaCheckSum() {
@@ -795,6 +872,7 @@ csi-proxy:
         Test-RancherConnection
         Stop-Agent -ServiceName $serviceName
         Invoke-WinsAgentDownload
+        Invoke-WinsUninstallScriptDownload
         Copy-WinsForCharts
         Set-WinsConfig
 

--- a/install.ps1
+++ b/install.ps1
@@ -301,7 +301,6 @@ function Invoke-WinsInstaller {
             if (-Not $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION) {
                 Write-LogFatal "No local uninstall location was specified"
             }
-            Write-LogInfo "Using local uninstall script from $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION"
             $env:UNINSTALL_SOURCE = "local"
         }
         else {

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -101,7 +101,7 @@ func Validate() error {
 }
 
 func BuildAll() error {
-	mg.SerialDeps(Build, BuildSUC, Validate)
+	mg.SerialDeps(Build, BuildSUC, BuildTestService, Validate)
 	return nil
 }
 
@@ -191,6 +191,20 @@ func BuildSUC() error {
 	return nil
 }
 
+func BuildTestService() error {
+	mg.Deps(Clean, Dependencies)
+	testServiceOutput := filepath.Join(integrationBin, "test_service.exe")
+
+	log.Println("[Build] Building test service")
+	log.Printf("[Build] Output: %s \n", testServiceOutput)
+	if err := g.Build(testServiceFlags, "./tests/integration/testservice", testServiceOutput); err != nil {
+		return err
+	}
+	log.Println("[Build] successfully built test service")
+
+	return nil
+}
+
 func Test() error {
 	mg.Deps(BuildAll)
 	log.Printf("[Test] Testing wins version %s \n", version)
@@ -237,4 +251,8 @@ func CI() {
 
 func flags(version string, commit string) string {
 	return fmt.Sprintf(`-s -w -X github.com/rancher/wins/pkg/defaults.AppVersion=%s -X github.com/rancher/wins/pkg/defaults.AppCommit=%s -extldflags "-static"`, version, commit)
+}
+
+func testServiceFlags(_ string, _ string) string {
+	return `-s -w -extldflags "-static"`
 }

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -102,7 +102,7 @@ func Validate() error {
 }
 
 func BuildAll() error {
-	mg.SerialDeps(Build, BuildSUC, Validate)
+	mg.SerialDeps(Build, BuildSUC, BuildTestService, Validate)
 	return nil
 }
 
@@ -213,6 +213,20 @@ func BuildSUC() error {
 	return nil
 }
 
+func BuildTestService() error {
+	mg.Deps(Clean, Dependencies)
+	testServiceOutput := filepath.Join(integrationBin, "test_service.exe")
+
+	log.Println("[Build] Building test service")
+	log.Printf("[Build] Output: %s \n", testServiceOutput)
+	if err := g.Build(testServiceFlags, "./tests/integration/testservice", testServiceOutput); err != nil {
+		return err
+	}
+	log.Println("[Build] successfully built test service")
+
+	return nil
+}
+
 func Test() error {
 	mg.Deps(BuildAll)
 	log.Printf("[Test] Testing wins version %s \n", version)
@@ -275,4 +289,8 @@ func normalizeFileLineEndingsToLF(path string) error {
 	}
 
 	return os.WriteFile(path, normalized, 0644)
+}
+
+func testServiceFlags(_ string, _ string) string {
+	return `-s -w -extldflags "-static"`
 }

--- a/tests/integration/testservice/main.go
+++ b/tests/integration/testservice/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+type handler struct{}
+
+func (h *handler) Execute(
+	args []string,
+	requests <-chan svc.ChangeRequest,
+	status chan<- svc.Status,
+) (bool, uint32) {
+
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+	status <- svc.Status{State: svc.Running, Accepts: accepted}
+
+	for req := range requests {
+		switch req.Cmd {
+		case svc.Stop, svc.Shutdown:
+			status <- svc.Status{State: svc.Stopped}
+			return false, 0
+		}
+	}
+
+	return false, 0
+}
+
+func main() {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to detect service context: %v\n", err)
+		os.Exit(1)
+	}
+
+	if isService {
+		serviceName := "test"
+
+		if len(os.Args) > 1 {
+			serviceName = os.Args[1]
+		}
+		if err := svc.Run(serviceName, &handler{}); err != nil {
+			fmt.Fprintf(os.Stderr, "service failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	time.Sleep(15 * time.Minute)
+}

--- a/tests/integration/uninstall_test.ps1
+++ b/tests/integration/uninstall_test.ps1
@@ -1,0 +1,452 @@
+$ErrorActionPreference = "Stop"
+
+Import-Module -Name @(
+    "$PSScriptRoot\utils.psm1"
+) -WarningAction Ignore
+
+function New-DummyService {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [string]$DisplayName = $Name
+    )
+
+    Remove-DummyService -Name $Name
+
+    $testExe   = "tests\integration\bin\test_service.exe"
+    $svcExe    = "$PSScriptRoot\$Name-svc.exe"
+    Copy-Item $testExe $svcExe -Force
+
+    $result = sc.exe create $Name binPath= "$svcExe $Name" start= demand DisplayName= $DisplayName
+    if ($LASTEXITCODE -ne 0) {
+        throw "sc.exe create failed for '$Name': $result"
+    }
+
+    Start-Service -Name $Name
+
+    $timeout = 30
+    $elapsed = 0
+    while ((Get-Service -Name $Name).Status -ne 'Running' -and $elapsed -lt $timeout) {
+        Start-Sleep -Seconds 1
+        $elapsed++
+    }
+    if ((Get-Service -Name $Name).Status -ne 'Running') {
+        throw "Timed out waiting for dummy service '$Name' to reach Running state"
+    }
+    Log-Info "Dummy service '$Name' is Running"
+}
+
+function Remove-DummyService {
+    param([Parameter(Mandatory)][string]$Name)
+
+    $svc = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($svc) {
+        if ($svc.Status -ne 'Stopped') {
+            Stop-Service -Name $Name -Force -ErrorAction SilentlyContinue
+            $timeout = 30
+            $elapsed = 0
+            while ((Get-Service -Name $Name -ErrorAction SilentlyContinue).Status -ne 'Stopped' -and $elapsed -lt $timeout) {
+                Start-Sleep -Seconds 1
+                $elapsed++
+            }
+        }
+        sc.exe delete $Name | Out-Null
+        Log-Info "Removed dummy service '$Name'"
+    }
+
+    # Remove the copied service binary regardless of whether the service existed
+    $svcExe = "$PSScriptRoot\$Name-svc.exe"
+    Remove-Item $svcExe -Force -ErrorAction SilentlyContinue
+}
+
+function New-DummyProcess {
+    param([Parameter(Mandatory)][string]$Name)
+
+    Remove-DummyProcess -Name $Name
+
+    $testExe  = "tests\integration\bin\test_service.exe"
+    $dummyExe = "$PSScriptRoot\$Name.exe"
+    Copy-Item $testExe $dummyExe -Force
+
+    Start-Process -FilePath $dummyExe -WindowStyle Hidden
+
+    $timeout = 15
+    $elapsed = 0
+    while (-not (Get-Process -Name $Name -ErrorAction SilentlyContinue) -and $elapsed -lt $timeout) {
+        Start-Sleep -Seconds 1
+        $elapsed++
+    }
+    if (-not (Get-Process -Name $Name -ErrorAction SilentlyContinue)) {
+        throw "Dummy process '$Name' did not appear within $timeout seconds"
+    }
+    Log-Info "Dummy process '$Name' is running"
+}
+
+function Remove-DummyProcess {
+    param([Parameter(Mandatory)][string]$Name)
+
+    Get-Process -Name $Name -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+    $timeout = 15
+    $elapsed = 0
+    while ((Get-Process -Name $Name -ErrorAction SilentlyContinue) -and $elapsed -lt $timeout) {
+        Start-Sleep -Seconds 1
+        $elapsed++
+    }
+
+    $dummyExe = "$PSScriptRoot\$Name.exe"
+    Remove-Item $dummyExe -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-Uninstaller {
+    powershell.exe -NonInteractive -File ".\uninstaller-test.ps1" | Write-Host
+    return ($LASTEXITCODE -eq 0)
+}
+
+# ---------------------------------------------------------------------------
+# Pre-suite: remove any leftovers from previous runs
+# ---------------------------------------------------------------------------
+try {
+    Remove-DummyService -Name "rancher-wins"
+    Remove-DummyService -Name "csiproxy"
+    Remove-DummyService -Name "rke2"
+    Remove-DummyProcess -Name "rke2"
+    Remove-DummyProcess -Name "wins"
+    Remove-DummyProcess -Name "csi-proxy"
+    Get-NetFirewallRule -PolicyStore ActiveStore -Name "rancher-wins-*" -ErrorAction Ignore | ForEach-Object { Remove-NetFirewallRule -Name $_.Name -PolicyStore ActiveStore -ErrorAction Ignore } | Out-Null
+}
+catch {
+    Log-Warn $_.Exception.Message
+}
+
+Describe "uninstall" {
+
+    BeforeEach {
+        Log-Info "Setting up environment for uninstall test"
+
+        $env:CATTLE_AGENT_CONFIG_DIR = "C:/etc/rancher/wins"
+        $env:CATTLE_AGENT_VAR_DIR    = "C:/var/lib/rancher/agent"
+
+        New-Item -Path $env:CATTLE_AGENT_CONFIG_DIR -ItemType Directory -Force | Out-Null
+        New-Item -Path $env:CATTLE_AGENT_VAR_DIR    -ItemType Directory -Force | Out-Null
+        New-Item -Path "C:/windows/wins.exe"         -ItemType File      -Force | Out-Null
+
+        Copy-Item uninstall.ps1 uninstaller-test.ps1 -Force
+    }
+
+    AfterEach {
+        Log-Info "Cleaning up after uninstall test"
+
+        # clean up ALL dummy services and processes so a failed test
+        # cannot leave behind a stale rke2/wins/csi-proxy that poisons the next test.
+        Remove-DummyService -Name "rancher-wins"
+        Remove-DummyService -Name "csiproxy"
+        Remove-DummyService -Name "rke2"
+        Remove-DummyProcess -Name "rke2"
+        Remove-DummyProcess -Name "wins"
+        Remove-DummyProcess -Name "csi-proxy"
+
+        # removing paths related to script
+        Remove-Item -Path "C:/etc/rancher/wins"        -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "C:/var/lib/rancher/agent"   -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "C:/windows/wins.exe"        -Force          -ErrorAction Ignore
+        Remove-Item -Path "C:/etc/windows-exporter"    -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "C:/etc/wmi-exporter"        -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "C:/tmp/test-wins-config"    -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "C:/tmp/test-wins-var"       -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path "uninstaller-test.ps1"       -Force          -ErrorAction Ignore
+
+        Remove-Item Env:\CATTLE_AGENT_LOGLEVEL -ErrorAction Ignore
+    }
+
+    # -------------------------------------------------------------------------
+    # RKE2 safeguard
+    # -------------------------------------------------------------------------
+
+    It "aborts uninstall when a real rke2 service is running" {
+        Log-Info "TEST: [aborts uninstall when a real rke2 service is running]"
+
+        New-DummyService -Name "rke2"         -DisplayName "RKE2 (test dummy)"
+        New-DummyService -Name "rancher-wins" -DisplayName "Rancher Wins (test dummy)"
+        New-DummyService -Name "csiproxy"     -DisplayName "CSI Proxy (test dummy)"
+
+        (Get-Service -Name "rke2").Status | Should -Be "Running"
+
+        $succeeded = Invoke-Uninstaller
+
+        # Script must have aborted — Invoke-Uninstaller should return $false
+        $succeeded | Should -Be $false
+
+        # Config dir must still be present — Remove-WinsConfig was never reached
+        Test-Path $env:CATTLE_AGENT_CONFIG_DIR | Should -Be $true
+
+        # Dependent services must still be intact — no teardown should have occurred
+        (Get-Service -Name "rancher-wins" -ErrorAction SilentlyContinue).Status | Should -Be "Running"
+        (Get-Service -Name "csiproxy"     -ErrorAction SilentlyContinue).Status | Should -Be "Running"
+    }
+
+    It "aborts uninstall when a real rke2 process is running" {
+        Log-Info "TEST: [aborts uninstall when a real rke2 process is running]"
+
+        New-DummyProcess -Name "rke2"
+        New-DummyService -Name "rancher-wins" -DisplayName "Rancher Wins (test dummy)"
+        New-DummyService -Name "csiproxy"     -DisplayName "CSI Proxy (test dummy)"
+
+        (Get-Process -Name "rke2" -ErrorAction SilentlyContinue) | Should -Not -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        # Script must have aborted — Invoke-Uninstaller should return $false
+        $succeeded | Should -Be $false
+
+        # Config dir must still be present — Remove-WinsConfig was never reached
+        Test-Path $env:CATTLE_AGENT_CONFIG_DIR | Should -Be $true
+
+        # Dependent services must still be intact — no teardown should have occurred
+        (Get-Service -Name "rancher-wins" -ErrorAction SilentlyContinue).Status | Should -Be "Running"
+        (Get-Service -Name "csiproxy"     -ErrorAction SilentlyContinue).Status | Should -Be "Running"
+    }
+
+    It "proceeds with uninstall when rke2 is not running" {
+        Log-Info "TEST: [proceeds with uninstall when rke2 is not running]"
+
+        (Get-Service -Name "rke2" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+        (Get-Process -Name "rke2" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path $env:CATTLE_AGENT_CONFIG_DIR | Should -Be $false
+    }
+
+    # -------------------------------------------------------------------------
+    # Agent config and var directory removal
+    # -------------------------------------------------------------------------
+
+    It "removes CATTLE_AGENT_CONFIG_DIR after uninstall" {
+        Log-Info "TEST: [removes CATTLE_AGENT_CONFIG_DIR after uninstall]"
+
+        Test-Path $env:CATTLE_AGENT_CONFIG_DIR | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path $env:CATTLE_AGENT_CONFIG_DIR | Should -Be $false
+    }
+
+    It "removes CATTLE_AGENT_VAR_DIR after uninstall" {
+        Log-Info "TEST: [removes CATTLE_AGENT_VAR_DIR after uninstall]"
+
+        Test-Path $env:CATTLE_AGENT_VAR_DIR | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path $env:CATTLE_AGENT_VAR_DIR | Should -Be $false
+    }
+
+    It "removes nested files inside CATTLE_AGENT_CONFIG_DIR" {
+        Log-Info "TEST: [removes nested files inside CATTLE_AGENT_CONFIG_DIR]"
+
+        $nestedFile = "$env:CATTLE_AGENT_CONFIG_DIR/config"
+        New-Item -Path $nestedFile -ItemType File -Force | Out-Null
+        Test-Path $nestedFile | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path $nestedFile | Should -Be $false
+    }
+
+    It "removes custom CATTLE_AGENT_CONFIG_DIR and CATTLE_AGENT_VAR_DIR after uninstall" {
+        Log-Info "TEST: [removes custom CATTLE_AGENT_CONFIG_DIR and CATTLE_AGENT_VAR_DIR after uninstall]"
+
+        $originalConfigDir = "C:/etc/rancher/wins"
+        $originalVarDir    = "C:/var/lib/rancher/agent"
+
+        $customConfigDir = "C:/tmp/test-wins-config"
+        $customVarDir    = "C:/tmp/test-wins-var"
+
+        $env:CATTLE_AGENT_CONFIG_DIR = $customConfigDir
+        $env:CATTLE_AGENT_VAR_DIR    = $customVarDir
+
+        New-Item -Path $customConfigDir -ItemType Directory -Force | Out-Null
+        New-Item -Path $customVarDir -ItemType Directory -Force | Out-Null
+
+        Test-Path $customConfigDir | Should -Be $true
+        Test-Path $customVarDir | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+
+        # Custom dirs should be removed
+        Test-Path $customConfigDir | Should -Be $false
+        Test-Path $customVarDir | Should -Be $false
+
+        # Default dirs from BeforeEach should NOT be removed by this run
+        Test-Path $originalConfigDir | Should -Be $true
+        Test-Path $originalVarDir | Should -Be $true
+    }
+
+    # -------------------------------------------------------------------------
+    # wins.exe removal (wins-for-charts)
+    # -------------------------------------------------------------------------
+
+    It "removes wins.exe from C:/windows after uninstall" {
+        Log-Info "TEST: [removes wins.exe from C:/windows after uninstall]"
+
+        Test-Path "C:/windows/wins.exe" | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/windows/wins.exe" | Should -Be $false
+    }
+
+    It "does not fail when wins.exe is already absent from C:/windows" {
+        Log-Info "TEST: [does not fail when wins.exe is already absent from C:/windows]"
+
+        Remove-Item "C:/windows/wins.exe" -Force -ErrorAction Ignore
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    # -------------------------------------------------------------------------
+    # Exporter directory removal
+    # -------------------------------------------------------------------------
+
+    It "deletes windows-exporter when only windows-exporter exists" {
+        Log-Info "TEST: [deletes windows-exporter when only windows-exporter exists]"
+
+        New-Item -Path "C:/etc/windows-exporter" -ItemType Directory -Force | Out-Null
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/etc/windows-exporter" | Should -Be $false
+    }
+
+    It "deletes wmi-exporter when only wmi-exporter exists" {
+        Log-Info "TEST: [deletes wmi-exporter when only wmi-exporter exists]"
+
+        New-Item -Path "C:/etc/wmi-exporter" -ItemType Directory -Force | Out-Null
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/etc/wmi-exporter" | Should -Be $false
+    }
+
+    It "does not fail when neither exporter directory exists" {
+        Log-Info "TEST: [does not fail when neither exporter directory exists]"
+
+        Remove-Item "C:/etc/windows-exporter" -Recurse -Force -ErrorAction Ignore
+        Remove-Item "C:/etc/wmi-exporter"     -Recurse -Force -ErrorAction Ignore
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    # -------------------------------------------------------------------------
+    # Service Cleanup
+    # -------------------------------------------------------------------------
+
+    It "stops and removes rancher-wins service if it is running" {
+        Log-Info "TEST: [stops and removes rancher-wins service if it is running]"
+
+        New-DummyService -Name "rancher-wins" -DisplayName "Rancher Wins (test dummy)"
+
+        (Get-Service -Name "rancher-wins").Status | Should -Be "Running"
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        (Get-Service -Name "rancher-wins" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+    }
+
+    It "does not fail when rancher-wins service is not installed" {
+        Log-Info "TEST: [does not fail when rancher-wins service is not installed]"
+
+        (Get-Service -Name "rancher-wins" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    It "stops and removes csiproxy service if it is running" {
+        Log-Info "TEST: [stops and removes csiproxy service if it is running]"
+
+        New-DummyService -Name "csiproxy" -DisplayName "CSI Proxy (test dummy)"
+
+        (Get-Service -Name "csiproxy").Status | Should -Be "Running"
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        (Get-Service -Name "csiproxy" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+    }
+
+    It "does not fail when csiproxy service is not installed" {
+        Log-Info "TEST: [does not fail when csiproxy service is not installed]"
+
+        (Get-Service -Name "csiproxy" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    # -------------------------------------------------------------------------
+    # Process Cleanup
+    # -------------------------------------------------------------------------
+
+    It "stops wins process if it is running" {
+        Log-Info "TEST: [stops wins process if it is running]"
+
+        New-DummyProcess -Name "wins"
+
+        (Get-Process -Name "wins" -ErrorAction SilentlyContinue) | Should -Not -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        (Get-Process -Name "wins" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+    }
+
+    It "does not fail when wins process is not running" {
+        Log-Info "TEST: [does not fail when wins process is not running]"
+
+        (Get-Process -Name "wins" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    It "stops csi-proxy process if it is running" {
+        Log-Info "TEST: [stops csi-proxy process if it is running]"
+
+        New-DummyProcess -Name "csi-proxy"
+
+        (Get-Process -Name "csi-proxy" -ErrorAction SilentlyContinue) | Should -Not -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        (Get-Process -Name "csi-proxy" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+    }
+
+    It "does not fail when csi-proxy process is not running" {
+        Log-Info "TEST: [does not fail when csi-proxy process is not running]"
+
+        (Get-Process -Name "csi-proxy" -ErrorAction SilentlyContinue) | Should -BeNullOrEmpty
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+}

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -137,7 +137,7 @@ function Invoke-WinsUninstaller {
             if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
                 Write-LogInfo "$ProcessName process found, stopping now"
                 Stop-Process -Name $ProcessName
-                while (-Not(Get-Process -Name $ProcessName).HasExited) {
+                while (-Not (Get-Process -Name $ProcessName).HasExited) {
                     Write-LogInfo "Waiting for $ProcessName process to stop"
                     Start-Sleep -s 5
                 }

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -102,10 +102,10 @@ function Invoke-WinsUninstaller {
         Remove-Item -Path $env:CATTLE_AGENT_CONFIG_DIR -Recurse -Force
         Remove-Item -Path $env:CATTLE_AGENT_VAR_DIR -Recurse -Force
         if (Test-Path "C:/etc/windows-exporter") {
-            Remove-Item -Path "C:/etc/wmi-exporter" -Recurse -Force
+            Remove-Item -Path "C:/etc/windows-exporter" -Recurse -Force
         }
         if (Test-Path "C:/etc/wmi-exporter") {
-            Remove-Item -Path "C:/etc/windows-exporter" -Recurse -Force
+            Remove-Item -Path "C:/etc/wmi-exporter" -Recurse -Force
         }
     }
 
@@ -147,6 +147,20 @@ function Invoke-WinsUninstaller {
         }
     }
 
+    function Remove-Service () {
+        param (
+            [Parameter()]
+            [string]
+            $ServiceName
+        )
+        
+        if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+            Write-LogInfo "$ServiceName service found, deleting now"
+            sc.exe delete $ServiceName
+            Write-LogInfo "$ServiceName service deleted"
+        }
+    }
+
     function Remove-WinsForCharts() {
         $winsForChartsPath = "c:/windows"
         if (Test-Path "$winsForChartsPath/wins.exe") {
@@ -167,8 +181,8 @@ function Invoke-WinsUninstaller {
         Stop-Processes
         Remove-WinsForCharts
         Remove-WinsConfig
-        sc.exe delete $csiProxyServiceName
-        sc.exe delete $serviceName
+        Remove-Service -ServiceName $csiProxyServiceName
+        Remove-Service -ServiceName $serviceName
     }
 
     Invoke-WinsAgentUninstall

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,81 +1,27 @@
 <#
-.SYNOPSIS 
-    Installs Rancher Wins to create Windows Worker Nodes.
-.DESCRIPTION 
-    Run the script to install all Rancher Wins related needs.
+.SYNOPSIS
+    Uninstalls Rancher Wins from Windows Worker Nodes.
+.DESCRIPTION
+    Run the script to uninstall all Rancher Wins related components.
+    This script will abort if RKE2 is currently running, as wins is primarily
+    used in the Rancher provisioning process and uninstalling while RKE2 is
+    active may leave the node in an inconsistent state.
 .NOTES
     Environment variables:
       System Agent Variables
       - CATTLE_AGENT_BIN_PREFIX (default: c:/usr/local)
       - CATTLE_AGENT_CONFIG_DIR (default: C:/etc/rancher/agent)
-      - CATTLE_AGENT_VAR_DIR (default: C:/var/lib/rancher/agent)     
-.EXAMPLE 
-    
+      - CATTLE_AGENT_VAR_DIR (default: C:/var/lib/rancher/agent)
+.EXAMPLE
+    ./uninstall.ps1
 #>
-#Make sure this params matches the CmdletBinding below
-param (
-    [Parameter()]
-    [String]
-    $Address,
-    [Parameter()]
-    [String]
-    $CaChecksum,
-    [Parameter()]
-    [String]
-    $InternalAddress,
-    [Parameter()]
-    [String]
-    $Label,
-    [Parameter()]
-    [String]
-    $NodeName,
-    [Parameter()]
-    [String]
-    $Server,
-    [Parameter()]
-    [String]
-    $Taint,
-    [Parameter()]
-    [String]
-    $Token,
-    [Parameter()]
-    [Switch]
-    $Worker
-)
+
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Invoke-WinsUninstaller {
     [CmdletBinding()]
-    param (
-        [Parameter()]
-        [String]
-        $Address,
-        [Parameter()]
-        [String]
-        $CaChecksum,
-        [Parameter()]
-        [String]
-        $InternalAddress,
-        [Parameter()]
-        [String]
-        $Label,
-        [Parameter()]
-        [String]
-        $NodeName,
-        [Parameter()]
-        [String]
-        $Server,
-        [Parameter()]
-        [String]
-        $Taint,
-        [Parameter()]
-        [String]
-        $Token,
-        [Parameter()]
-        [Switch]
-        $Worker
-    )
+    param ()
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
@@ -105,15 +51,13 @@ function Invoke-WinsUninstaller {
     }
 
     function Set-Environment {
-
         if (-Not $env:CATTLE_AGENT_LOGLEVEL) {
             $env:CATTLE_AGENT_LOGLEVEL = "debug"
         }
         else {
             $env:CATTLE_AGENT_LOGLEVEL = $env:CATTLE_AGENT_LOGLEVEL.ToLower()
         }
-       
-      
+
         if (-Not $env:CATTLE_AGENT_CONFIG_DIR) {
             $env:CATTLE_AGENT_CONFIG_DIR = "C:/etc/rancher/wins"
             Write-LogInfo "Using default agent configuration directory $( $env:CATTLE_AGENT_CONFIG_DIR )"
@@ -122,7 +66,7 @@ function Invoke-WinsUninstaller {
             New-Item -Path $env:CATTLE_AGENT_CONFIG_DIR -ItemType Directory -Force | Out-Null
         }
 
-        if (-Not $env:CATTLE_AGENT_VAR_DIR) {          
+        if (-Not $env:CATTLE_AGENT_VAR_DIR) {
             $env:CATTLE_AGENT_VAR_DIR = "C:/var/lib/rancher/agent"
             Write-LogInfo "Using default agent var directory $( $env:CATTLE_AGENT_VAR_DIR )"
         }
@@ -138,25 +82,40 @@ function Invoke-WinsUninstaller {
         }
     }
 
+    # Safeguard: abort uninstall if RKE2 is currently running.
+    # Wins is a core component of the Rancher/RKE2 provisioning process on Windows.
+    # Uninstalling while RKE2 is active risks leaving the node in a broken state.
+    function Assert-Rke2NotRunning {
+        Write-LogInfo "Checking if RKE2 is running"
+        $rke2Service = Get-Service -Name "rke2" -ErrorAction SilentlyContinue
+        if ($rke2Service -and $rke2Service.Status -eq 'Running') {
+            Write-LogFatal "RKE2 service is currently running. Stop RKE2 before uninstalling Wins to avoid leaving the node in an inconsistent state."
+        }
+        $rke2Process = Get-Process -Name "rke2" -ErrorAction SilentlyContinue
+        if ($rke2Process) {
+            Write-LogFatal "RKE2 process is currently running. Stop RKE2 before uninstalling Wins to avoid leaving the node in an inconsistent state."
+        }
+        Write-LogInfo "RKE2 is not running, proceeding with uninstall"
+    }
 
     function Remove-WinsConfig() {
         Remove-Item -Path $env:CATTLE_AGENT_CONFIG_DIR -Recurse -Force
         Remove-Item -Path $env:CATTLE_AGENT_VAR_DIR -Recurse -Force
         if (Test-Path "C:/etc/windows-exporter") {
-            Remove-Item -Path "C:/etc/wmi-exporter" -Recurse -Force 
-        }   
+            Remove-Item -Path "C:/etc/wmi-exporter" -Recurse -Force
+        }
         if (Test-Path "C:/etc/wmi-exporter") {
-            Remove-Item -Path "C:/etc/windows-exporter" -Recurse -Force 
+            Remove-Item -Path "C:/etc/windows-exporter" -Recurse -Force
         }
     }
 
-    function Stop-Agent() { 
+    function Stop-Agent() {
         [CmdletBinding()]
         param (
             [Parameter()]
             [string]
             $ServiceName
-        )       
+        )
         Write-LogInfo "Checking if $ServiceName service exists"
         if ((Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
             Write-LogInfo "$ServiceName service found, stopping now"
@@ -171,13 +130,29 @@ function Invoke-WinsUninstaller {
         }
     }
 
+    function Stop-Processes () {
+        $ProcessNames = @('csi-proxy', "wins")
+        foreach ($ProcessName in $ProcessNames) {
+            Write-LogInfo "Checking if $ProcessName process exists"
+            if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
+                Write-LogInfo "$ProcessName process found, stopping now"
+                Stop-Process -Name $ProcessName
+                while (-Not(Get-Process -Name $ProcessName).HasExited) {
+                    Write-LogInfo "Waiting for $ProcessName process to stop"
+                    Start-Sleep -s 5
+                }
+            } else {
+                Write-LogInfo "$ProcessName process not found"
+            }
+        }
+    }
+
     function Remove-WinsForCharts() {
         $winsForChartsPath = "c:/windows"
         if (Test-Path "$winsForChartsPath/wins.exe") {
             Remove-Item "$winsForChartsPath/wins.exe" -Force
-        }   
+        }
     }
-
 
     function Invoke-WinsAgentUninstall() {
         $serviceName = "rancher-wins"
@@ -185,12 +160,15 @@ function Invoke-WinsUninstaller {
         Set-Environment
         Set-Path
 
-        Stop-Agent -ServiceName $serviceName
+        Assert-Rke2NotRunning
+
         Stop-Agent -ServiceName $csiProxyServiceName
+        Stop-Agent -ServiceName $serviceName
+        Stop-Processes
         Remove-WinsForCharts
         Remove-WinsConfig
-        sc.exe delete $serviceName
         sc.exe delete $csiProxyServiceName
+        sc.exe delete $serviceName
     }
 
     Invoke-WinsAgentUninstall


### PR DESCRIPTION
### Summary
<!-- Add a link to a tracking GitHub issue, typically located in rancher/rancher -->
Issue: https://github.com/rancher/rancher/issues/51850
addresses the following points from the issue
- The parameters listed in the script are not needed, and can cause confusion when looking at the file for the first time
- The script does not explicitly stop the csi-proxy process, and may fail to remove the related service on first run
- It may be beneficial to automatically place this script onto nodes provisioned via Rancher, so that users can easily leverage it
- Safe guards could be implemented to prevent the uninstall script from executing if rke2 is running, as wins is primarily used in the Rancher provisioning process
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
**updates in the install.ps1 script**
1. it will now download and mount the uninstall.ps1 script on the node with the name `wins-agent-uninstall.ps1`. there is an environment variable to specify local uninstall.ps1 as well and `CATTLE_AGENT_UNINSTALL_URL` can be used to set the download url else `$env:CATTLE_AGENT_BINARY_BASE_URL/wins-agent-uninstall.ps1` is used. If no environment is provided then it will download from github release of the specified wins version
2. removed the logic of downloading the latest available wins.exe on github and added checksum verification for wins and uninstall script both.

**updates in uninstall.ps1 script**
1.  it will fail if rke2 process or service is running on the node.
2. removed unnecessary params from the script.
3. it will stop cisproxy service before wins service
4. it will stop csi-proxy and wins processes after stopping the services
5. check for service existence before deleting the service

**uninstall.ps1 tests"
1. added integration tests for uninstall.ps1 script.
for the tests created a test service in test/integration/testservice which will be used to generate an executable (test.exe) and that executable will be used to create dummy processes and services(rancher-wins and csi-proxy). Those will be then cleaned up by uninstall.ps1 script while testing.


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
the install.sh script will now auto mount the `uninstall.ps1` script on the nodes with the name `wins-agent-uninstall.ps1`.
and uninstall.ps1 script will now remove `cisproxy` service and the processes associated with `wins` and `cisproxy` services. 
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- provisioning rke2 clusters with windows worker nodes. since install.sh script is changed.
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- provisioning rke2 clusters with windows worker nodes
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->