### PR TITLE
fix: properly add artifacts to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,7 +204,7 @@ jobs:
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload -R "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}" /tmp/assets/*
+        run: gh release upload -R "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}" /tmp/assets/artifacts/* /tmp/assets/LICENSE
 
       - name: Publish the release
         env:


### PR DESCRIPTION
The recent changes for immutable releases didn't point to the correct directory when uploading artifacts. `mage.go` writes [the actual artifacts to the `artifacts` directory](https://github.com/rancher/wins/blob/main/magefiles/magefile.go#L24), but the workflow was attempting to upload everything using `/tmp/assets/*`. This causes an error, since you can't upload a directory to a release. 

This change just points to the correct paths for the resulting binaries and license. 