### PR TITLE
[main] normalize line endings of published install.ps1 and uninstall.ps1 script

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -121,11 +122,22 @@ func Build() error {
 		return err
 	}
 
-	if err := sh.Copy(filepath.Join(artifactOutput, "install.ps1"), "install.ps1"); err != nil {
+	installScriptOutputPath := filepath.Join(artifactOutput, "install.ps1")
+	uninstallScriptOutputPath := filepath.Join(artifactOutput, "uninstall.ps1")
+
+	if err := sh.Copy(installScriptOutputPath, "install.ps1"); err != nil {
 		return err
 	}
 
-	if err := sh.Copy(filepath.Join(artifactOutput, "uninstall.ps1"), "uninstall.ps1"); err != nil {
+	if err := normalizeFileLineEndingsToLF(installScriptOutputPath); err != nil {
+		return err
+	}
+
+	if err := sh.Copy(uninstallScriptOutputPath, "uninstall.ps1"); err != nil {
+		return err
+	}
+
+	if err := normalizeFileLineEndingsToLF(uninstallScriptOutputPath); err != nil {
 		return err
 	}
 
@@ -247,4 +259,20 @@ func CI() {
 
 func flags(version string, commit string) string {
 	return fmt.Sprintf(`-s -w -X github.com/rancher/wins/pkg/defaults.AppVersion=%s -X github.com/rancher/wins/pkg/defaults.AppCommit=%s -extldflags "-static"`, version, commit)
+}
+
+func normalizeFileLineEndingsToLF(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Convert CRLF -> LF
+	normalized := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+
+	if bytes.Equal(data, normalized) {
+		return nil
+	}
+
+	return os.WriteFile(path, normalized, 0644)
 }


### PR DESCRIPTION
### Summary
<!-- Add a link to a tracking GitHub issue, typically located in rancher/rancher -->
Issue:

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
noramlized the line endings of released install.ps1 and uninstall.ps1 scripts to LF to match sha sum with the raw github URLs.
it is needed since CI is running on windows runner.
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->