### PR TITLE
Improve handling of certificate chains

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -500,42 +500,56 @@ function Invoke-WinsInstaller {
     # Import-Certificates imports one or more
     # certificates stored in the file specified by $ENV:RANCHER_CERT.
     # In the event that $env:RANCHER_CERT contains multiple certificate
-    # blocks, a regular expression is used to iterate across all blocks
-    # and import them individually.
+    # blocks, a regular expression is used to iterate across all valid x509 blocks
+    # and import them individually. Errant non-certificate blocks and any lingering
+    #  whitespace are ignored.
     function Import-Certificates() {
-        $rawCerts = Get-Content $env:RANCHER_CERT -Raw
-        # splits blocks, handles
-        # CLRF line endings if present
-        $pattern  = "(?<=-\r?\n)(?=-+)"
-        $allCerts = $rawCerts -split $pattern
-
-        if ($allCerts.Length -eq 0) {
-            Write-LogWarn "No Certs found in certs file, check that $env:RANCHER_CERT exists and that the correct certificate is configured at $( $env:CATTLE_SERVER )/cacerts."
+        if (-Not (Test-Path $env:RANCHER_CERT)) {
+            Write-LogWarn "Certificate file not found at $env:RANCHER_CERT. Check that CATTLE_CA_CHECKSUM is correct and $($env:CATTLE_SERVER)/cacerts is reachable."
             return
         }
 
-        if ($allCerts.Length -eq 1) {
-            Write-LogInfo "Detected single certificate"
-            Import-Certificate -FilePath $env:RANCHER_CERT -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+        $certBlocks = [regex]::Matches(
+            (Get-Content $env:RANCHER_CERT -Raw),
+            '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----'
+        )
+
+        if ($certBlocks.Count -eq 0) {
+            Write-LogWarn "No valid certificate blocks found in $env:RANCHER_CERT. Check that the correct certificate is configured at $($env:CATTLE_SERVER)/cacerts."
             return
         }
 
-        # Import-Certificate does not automatically handle chains included in a single file,
-        # so we need to manually extract and import each certificate into the Root store.
-        Write-LogInfo "Detected certificate chain"
+        Write-LogInfo "Found $($certBlocks.Count) certificate(s) in $env:RANCHER_CERT"
 
-        $collection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        ForEach($cert in $allCerts) {
-            Write-LogInfo "Adding a certificate entry from the provided chain to the collection..."
-            $x5092 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new([System.Text.Encoding]::UTF8.GetBytes($cert))
-            $collection.Add($x5092)
-        }
-
-        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new([System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
+        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+            [System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
         $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::MaxAllowed)
-        Write-LogInfo "Adding collection to certificate store"
-        $certStore.AddRange($collection)
-        $certStore.Close()
+
+        try {
+            $imported = 0
+            foreach ($block in $certBlocks) {
+                try {
+                    $x509 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                        [System.Text.Encoding]::UTF8.GetBytes($block.Value))
+                    Write-LogInfo "Importing certificate: ThumbPrint='$($x509.Thumbprint)'"
+                    $certStore.Add($x509)
+                    $imported++
+                }
+                catch {
+                    Write-LogWarn "Failed to import a certificate block. Error: $($_.Exception.Message)"
+                }
+            }
+
+            if ($imported -eq 0) {
+                Write-LogWarn "No certificates were successfully imported from $env:RANCHER_CERT"
+            }
+            else {
+                Write-LogInfo "Successfully imported $imported of $($certBlocks.Count) certificate(s) into the Root store"
+            }
+        }
+        finally {
+            $certStore.Close()
+        }
     }
 
     function Test-RancherConnection {

--- a/install.ps1
+++ b/install.ps1
@@ -686,7 +686,49 @@ csi-proxy:
         Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $proxyConfig
     }
 
-    function Stop-Agent() { 
+    function Start-Agent() {
+        [CmdletBinding()]
+        param (
+            [Parameter()]
+            [string]
+            $ServiceName
+        )
+        if (-Not (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
+            Write-LogInfo "$ServiceName service not found, registering now."
+            Push-Location c:\usr\local\bin
+            try {
+                if ($env:CATTLE_ENABLE_WINS_DELAYED_START -eq "true") {
+                    wins.exe srv app run --register --delayed-start
+                } else {
+                    wins.exe srv app run --register
+                }
+            } catch {
+                Write-LogFatal "Failed to execute wins.exe: $($_.Exception.Message)"
+            }
+            Pop-Location
+            Start-Sleep -s 5
+        }
+
+        Write-LogInfo "Starting $ServiceName service."
+        try {
+            Start-Service -Name $ServiceName
+        } catch {
+            Write-LogFatal "$ServiceName failed to start: $($_.Exception.Message)"
+        }
+
+        $timeout = 120
+        $elapsed = 0
+        while ((Get-Service $ServiceName).Status -ne 'Running') {
+            if ($elapsed -ge $timeout) {
+                Write-LogFatal "$ServiceName did not reach 'Running' state within $timeout seconds."
+            }
+            Write-LogInfo "Waiting for $ServiceName service to start (${elapsed}s elapsed)."
+            Start-Sleep -s 5
+            $elapsed += 5
+        }
+    }
+
+    function Stop-Agent() {
         [CmdletBinding()]
         param (
             [Parameter()]
@@ -911,35 +953,7 @@ csi-proxy:
             }
         }
                 
-        try {
-            Write-LogInfo "Checking if $serviceName service exists."
-            Get-Service -Name $serviceName
-        }
-        catch {
-            Write-LogInfo "$serviceName service not found, enabling agent service."
-            Push-Location c:\usr\local\bin
-            if ($env:CATTLE_ENABLE_WINS_DELAYED_START -eq "true") {
-                wins.exe srv app run --register --delayed-start
-            } else {
-                wins.exe srv app run --register
-            }
-            Pop-Location
-            Start-Sleep -s 5
-        }
-
-        try
-        {
-            Write-LogInfo "Starting $serviceName service."
-            Start-Service -Name $serviceName
-        } catch {
-            Write-LogInfo "$serviceName failed to start. Check the $serviceName logs for more information"
-            Write-LogInfo "Command: Get-WinEvent -ProviderName $serviceName | select-object TimeCreated,Message | Format-Table -wrap"
-            exit 1
-        }
-        while ((Get-Service $serviceName).Status -ne 'Running') {
-            Write-LogInfo "Waiting for $serviceName service to start."
-            Start-Sleep -s 5
-        }
+        Start-Agent -ServiceName $serviceName
     }
 
     Confirm-WindowsFeatures -RequiredFeatures @("Containers")

--- a/install.ps1
+++ b/install.ps1
@@ -528,6 +528,7 @@ function Invoke-WinsInstaller {
         try {
             $imported = 0
             foreach ($block in $certBlocks) {
+                $x509 = $null
                 try {
                     $x509 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
                         [System.Text.Encoding]::UTF8.GetBytes($block.Value))
@@ -537,6 +538,10 @@ function Invoke-WinsInstaller {
                 }
                 catch {
                     Write-LogWarn "Failed to import a certificate block. Error: $($_.Exception.Message)"
+                } finally {
+                    if ($null -ne $x509) {
+                        $x509.Dispose()
+                    }
                 }
             }
 

--- a/install.ps1
+++ b/install.ps1
@@ -77,8 +77,8 @@ param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$FALLBACK = "v0.5.4"
-$FALLBACK_BINARY_SUM = "8fab9744af8f089a3cd7bea4fd3c70ec71842da80d8e1994f843a884026fd710"
+$FALLBACK = "v0.5.5"
+$FALLBACK_BINARY_SUM = "cb42373cad3260d3b628de3d18cad13c0825577337499e4b9a05dc8926300512"
 $FALLBACK_UNINSTALL_SUM  = "bcc0f990176079f7dc69e668907230ac785d4676e037eef5b70cf3316e614adc"
 
 function Invoke-WinsInstaller {

--- a/tests/integration/install_certs_test.ps1
+++ b/tests/integration/install_certs_test.ps1
@@ -159,6 +159,22 @@ Describe "Install script certificate tests" {
         check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
     }
 
+    It "Imports certs from a chain carrying PKCS#12 bundle metadata between blocks" {
+        Log-Info "TEST: [Imports certs from a chain carrying PKCS#12 bundle metadata between blocks]"
+        $certData = Setup-CertFiles -length 3
+        $mutated  = Add-PKCSBundleMetadata $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that all certs were imported despite the interleaved bag/subject/issuer metadata..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
     It "Imports valid certs from a file with a truncated final block" {
         Log-Info "TEST: [Imports valid certs from a file with a truncated final block]"
         $certData = Setup-CertFiles -length 2

--- a/tests/integration/install_certs_test.ps1
+++ b/tests/integration/install_certs_test.ps1
@@ -143,6 +143,22 @@ Describe "Install script certificate tests" {
         check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
     }
 
+    It "Imports valid certs from a file that contains a corrupted certificate block" {
+        Log-Info "TEST: [Imports valid certs from a file that contains a corrupted certificate block]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-CorruptCertBlock $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that valid certs were still imported despite the corrupted block..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
     It "Imports valid certs from a file with a truncated final block" {
         Log-Info "TEST: [Imports valid certs from a file with a truncated final block]"
         $certData = Setup-CertFiles -length 2
@@ -171,24 +187,30 @@ Describe "Install script certificate tests" {
 
             Log-Info "Starting mock Rancher API"
             $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $CertBlocks
-            Start-Sleep 1
-            if ($job.State -ne "Running") {
-                # display job output to help debug job failure
-                Log-Error "Mock Rancher server failed to start"
-                $job | Receive-Job
-                $job.State | Should -Be -ExpectedValue "Running"
+            try {
+                Start-Sleep 1
+                if ($job.State -ne "Running") {
+                    # display job output to help debug job failure
+                    Log-Error "Mock Rancher server failed to start"
+                    $job | Receive-Job
+                    $job.State | Should -Be -ExpectedValue "Running"
+                }
+
+                Log-Info "Invoking install script"
+                .\install-certs-test.ps1
+                $installScriptExitCode = $LASTEXITCODE
+
+                Log-Info "Install script exited with code $installScriptExitCode"
+                $installScriptExitCode | Should -Be -ExpectedValue 0
             }
-
-            Log-Info "Invoking install script"
-            .\install-certs-test.ps1
-            $installScriptExitCode = $LASTEXITCODE
-
-            Log-Info "Stopping mock server"
-            curl.exe -sS http://localhost:8080/kill
-            Remove-Job -Id $job.Id -Force
-
-            Log-Info "Install script exited with code $installScriptExitCode"
-            $installScriptExitCode | Should -Be -ExpectedValue 0
+            finally {
+                # Always tear down the mock server, even if it never came up or an
+                # assertion above threw, so a single failure can't leak port 8080
+                # and cascade into every other test in this file.
+                Log-Info "Stopping mock server"
+                curl.exe -sS --max-time 5 http://localhost:8080/kill 2>&1 | Out-Null
+                Remove-Job -Id $job.Id -Force -ErrorAction SilentlyContinue
+            }
         }
 
         function check-thumbprints() {

--- a/tests/integration/install_certs_test.ps1
+++ b/tests/integration/install_certs_test.ps1
@@ -111,17 +111,66 @@ Describe "Install script certificate tests" {
         Log-Info "Properly imported $expectedCertificates certificates"
     }
 
+    It "Imports certs from a file with extra blank lines between blocks" {
+        Log-Info "TEST: [Imports certs from a file with extra blank lines between blocks]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-ExtraNewlines $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that certs have been properly imported..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports certs from a file that contains a non-certificate PEM entry" {
+        Log-Info "TEST: [Imports certs from a file that contains a non-certificate PEM entry]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-FakePemEntry $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that certs have been properly imported..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports valid certs from a file with a truncated final block" {
+        Log-Info "TEST: [Imports valid certs from a file with a truncated final block]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Remove-LastCertEnd $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming import results: root cert should be imported, truncated leaf cert should not"
+        check-thumbprints -shouldExist $true  -thumbs @($certData.ThumbPrints[0])
+        check-thumbprints -shouldExist $false -thumbs @($certData.ThumbPrints[1])
+    }
+
     # utility functions only useful for this set of tests
     BeforeAll {
         function invoke-installScript() {
             param (
                 [Parameter()]
                 [String]
-                $certs
+                $CertBlocks = $certData.FinalCertBlocks
             )
 
             Log-Info "Starting mock Rancher API"
-            $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $certData.FinalCertBlocks
+            $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $CertBlocks
             Start-Sleep 1
             if ($job.State -ne "Running") {
                 # display job output to help debug job failure

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -490,6 +490,15 @@ function Add-FakePemEntry {
     return $fake + "`n" + $CertData
 }
 
+# Unlike Add-FakePemEntry, this wraps garbage base64 in a genuine
+# CERTIFICATE marker so it passes the regex match in Import-Certificates
+# but fails to parse as an X509Certificate2, exercising the per-block catch.
+function Add-CorruptCertBlock {
+    param([string]$CertData)
+    $corrupt = "-----BEGIN CERTIFICATE-----`nVGhpcyBpcyBub3QgYSB2YWxpZCBjZXJ0aWZpY2F0ZQ==`n-----END CERTIFICATE-----"
+    return $corrupt + "`n" + $CertData
+}
+
 # Removes the last END CERTIFICATE marker, leaving the final block truncated
 function Remove-LastCertEnd {
     param([string]$CertData)
@@ -529,5 +538,6 @@ Export-ModuleMember -Function Ensure-DependencyExistsForService
 Export-ModuleMember -Function Get-LatestCommitOrTag
 Export-ModuleMember -Function Add-ExtraNewlines
 Export-ModuleMember -Function Add-FakePemEntry
+Export-ModuleMember -Function Add-CorruptCertBlock
 Export-ModuleMember -Function Remove-LastCertEnd
 Export-ModuleMember -Function Get-StringChecksum

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -479,6 +479,35 @@ function newCert() {
     return $null
 }
 
+function Add-ExtraNewlines {
+    param([string]$CertData)
+    return $CertData -replace '-----END CERTIFICATE-----', "-----END CERTIFICATE-----`n`n"
+}
+
+function Add-FakePemEntry {
+    param([string]$CertData, [string]$EntryType = "PRIVATE KEY")
+    $fake = "-----BEGIN $EntryType-----`nZmFrZWRhdGE=`n-----END $EntryType-----"
+    return $fake + "`n" + $CertData
+}
+
+# Removes the last END CERTIFICATE marker, leaving the final block truncated
+function Remove-LastCertEnd {
+    param([string]$CertData)
+    $idx = $CertData.LastIndexOf("-----END CERTIFICATE-----")
+    if ($idx -ge 0) { return $CertData.Substring(0, $idx) }
+    return $CertData
+}
+
+# Hashes an in-memory string the same way Test-CaCheckSum hashes the downloaded file
+function Get-StringChecksum {
+    param([string]$Data)
+    $tmp = New-TemporaryFile
+    Set-Content -NoNewline -Path $tmp.FullName -Value $Data
+    $hash = (Get-FileHash -Path $tmp.FullName -Algorithm SHA256).Hash.ToLower()
+    Remove-Item $tmp.FullName -Force
+    return $hash
+}
+
 Export-ModuleMember -Function Setup-CertFiles
 Export-ModuleMember -Function Cleanup-CertFile
 Export-ModuleMember -Function Log-Info
@@ -498,3 +527,7 @@ Export-ModuleMember -Function Get-Permissions
 Export-ModuleMember -Function Test-Permissions
 Export-ModuleMember -Function Ensure-DependencyExistsForService
 Export-ModuleMember -Function Get-LatestCommitOrTag
+Export-ModuleMember -Function Add-ExtraNewlines
+Export-ModuleMember -Function Add-FakePemEntry
+Export-ModuleMember -Function Remove-LastCertEnd
+Export-ModuleMember -Function Get-StringChecksum

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -507,6 +507,40 @@ function Remove-LastCertEnd {
     return $CertData
 }
 
+# Add-PKCSBundleMetadata rebuilds the chain so that each certificate block is
+# preceded by the human-readable metadata that
+# `openssl pkcs12 -in bundle.pfx -nokeys -out chain.pem` emits when a PKCS#12
+# bundle is extracted into a plain cacert chain. openssl writes a "Bag
+# Attributes" section plus subject=/issuer= lines ahead of every block, which
+# places errant metadata both before the first cert and between every
+# subsequent block.
+function Add-PKCSBundleMetadata {
+    param([string]$CertData)
+
+    $blocks = [regex]::Matches($CertData, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+    $sb = [System.Text.StringBuilder]::new()
+    for ($j = 0; $j -lt $blocks.Count; $j++) {
+        if ($j -eq 0) {
+            $meta = @"
+Bag Attributes
+    localKeyID: 01 A2 B3 C4 D5 E6 F7 08 19 2A 3B 4C 5D 6E 7F 80
+    friendlyName: rancher
+subject=CN = wins-test-leaf-cert
+issuer=CN = wins-test-intermediate-cert
+"@
+        } else {
+            $meta = @"
+Bag Attributes: <No Attributes>
+subject=CN = wins-test-ca-cert
+issuer=CN = wins-test-root-CA
+"@
+        }
+        [void]$sb.AppendLine($meta)
+        [void]$sb.AppendLine($blocks[$j].Value)
+    }
+    return $sb.ToString()
+}
+
 # Hashes an in-memory string the same way Test-CaCheckSum hashes the downloaded file
 function Get-StringChecksum {
     param([string]$Data)
@@ -540,4 +574,5 @@ Export-ModuleMember -Function Add-ExtraNewlines
 Export-ModuleMember -Function Add-FakePemEntry
 Export-ModuleMember -Function Add-CorruptCertBlock
 Export-ModuleMember -Function Remove-LastCertEnd
+Export-ModuleMember -Function Add-PKCSBundleMetadata
 Export-ModuleMember -Function Get-StringChecksum


### PR DESCRIPTION
### Summary
Issue: https://github.com/rancher/rancher/issues/55817

### Occurred changes and/or fixed issues

The current `install.ps1` uses a fairly fragile regex to parse certificate chains returned from the `/cacerts` endpoint. Under normal circumstances, where the Rancher configuration strictly follows the documentation, the current implementation works as expected. However, it does not handle slight misconfigurations, such as errant new lines, or the inclusion of other PKI information such as private keys. While both of those scenarios differ from the provided documentation and should be considered misconfigurations, `curl` is able to more gracefully handle these cases. 

This PR improves the regex used to break the obtained certificate chain into independent entries and import them individually into the windows certificate store. It also improves how the wins agent binary is executed, to return more detailed error logging if the binary fails to start up. Integration tests are also expanded to handle the new certificate logic. 

### Technical notes summary


### Areas or cases that should be tested
Creating custom or provisioned windows nodes in Rancher environments which use custom self signed certificated, served via `/cacerts`

### Areas which could experience regressions
Windows node registration / provisioning


### Screenshot/Video
