### PR TITLE
[2.14] Normalize line endings in install and uninstall scripts

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -121,11 +122,22 @@ func Build() error {
 		return err
 	}
 
-	if err := sh.Copy(filepath.Join(artifactOutput, "install.ps1"), "install.ps1"); err != nil {
+	installScriptOutputPath := filepath.Join(artifactOutput, "install.ps1")
+	uninstallScriptOutputPath := filepath.Join(artifactOutput, "uninstall.ps1")
+
+	if err := sh.Copy(installScriptOutputPath, "install.ps1"); err != nil {
 		return err
 	}
 
-	if err := sh.Copy(filepath.Join(artifactOutput, "uninstall.ps1"), "uninstall.ps1"); err != nil {
+	if err := normalizeFileLineEndingsToLF(installScriptOutputPath); err != nil {
+		return err
+	}
+
+	if err := sh.Copy(uninstallScriptOutputPath, "uninstall.ps1"); err != nil {
+		return err
+	}
+
+	if err := normalizeFileLineEndingsToLF(uninstallScriptOutputPath); err != nil {
 		return err
 	}
 
@@ -247,4 +259,20 @@ func CI() {
 
 func flags(version string, commit string) string {
 	return fmt.Sprintf(`-s -w -X github.com/rancher/wins/pkg/defaults.AppVersion=%s -X github.com/rancher/wins/pkg/defaults.AppCommit=%s -extldflags "-static"`, version, commit)
+}
+
+func normalizeFileLineEndingsToLF(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Convert CRLF -> LF
+	normalized := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+
+	if bytes.Equal(data, normalized) {
+		return nil
+	}
+
+	return os.WriteFile(path, normalized, 0644)
 }


### PR DESCRIPTION
Backport https://github.com/rancher/wins/commit/6dfbf2111f93da4bcec7294c826495f7ee953bca, which is needed to make sure that the install and uninstall script artifacts do not use carriage return line endings. 
 
We will need to cut a new RC tag for the updatecli in r/r to pick up the correct values. 