### PR TITLE
[2.14] Backport Improved handling of certificate chains

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -269,7 +269,7 @@ function Invoke-WinsInstaller {
 
             if (-Not $env:CATTLE_AGENT_BINARY_URL) {
                 $rateLimit = $(curl.exe --connect-timeout 60 --max-time 300 $env:CURL_CAFLAG -sfL "https://api.github.com/rate_limit") | ConvertFrom-Json
-               
+
                 if ($rateLimit.rate.remaining -eq 0) {
                     Write-LogInfo "Error contacting GitHub to retrieve the latest version, falling back to version: $FALLBACK"
                     $env:VERSION = $FALLBACK
@@ -346,7 +346,7 @@ function Invoke-WinsInstaller {
         if (-Not (Test-Path "$env:CATTLE_AGENT_BIN_PREFIX/bin")) {
             New-Item -Path "$env:CATTLE_AGENT_BIN_PREFIX/bin" -ItemType Directory -Force | Out-Null
         }
-        
+
         if ($env:CATTLE_AGENT_BINARY_LOCAL -eq "true") {
             Write-LogInfo "Using local Wins installer from $($env:CATTLE_AGENT_BINARY_LOCAL_LOCATION)"
             Copy-Item -Path $env:CATTLE_AGENT_BINARY_LOCAL_LOCATION -Destination "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe"
@@ -360,18 +360,18 @@ function Invoke-WinsInstaller {
                 $env:CURL_BIN_CAFLAG = ""
             }
 
-            $retries = 0  
+            $retries = 0
             while ($retries -lt 6) {
                 $responseCode = $(curl.exe --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" $env:CURL_BIN_CAFLAG -sfL "$($env:CATTLE_AGENT_BINARY_URL)" -o "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins.exe")
-                
+
                 switch ( $responseCode ) {
                     { "ok200", 200 } {
-                        Write-LogInfo "Successfully downloaded the wins binary." 
+                        Write-LogInfo "Successfully downloaded the wins binary."
                         $retries = 99
                         break
                     }
                     default {
-                        Write-LogError "$responseCode received while downloading the wins binary. Sleeping for 5 seconds and trying again." 
+                        Write-LogError "$responseCode received while downloading the wins binary. Sleeping for 5 seconds and trying again."
                         Start-Sleep -Seconds 5
                         $retries++
                         continue
@@ -420,42 +420,61 @@ function Invoke-WinsInstaller {
     # Import-Certificates imports one or more
     # certificates stored in the file specified by $ENV:RANCHER_CERT.
     # In the event that $env:RANCHER_CERT contains multiple certificate
-    # blocks, a regular expression is used to iterate across all blocks
-    # and import them individually.
+    # blocks, a regular expression is used to iterate across all valid x509 blocks
+    # and import them individually. Errant non-certificate blocks and any lingering
+    #  whitespace are ignored.
     function Import-Certificates() {
-        $rawCerts = Get-Content $env:RANCHER_CERT -Raw
-        # splits blocks, handles
-        # CLRF line endings if present
-        $pattern  = "(?<=-\r?\n)(?=-+)"
-        $allCerts = $rawCerts -split $pattern
-
-        if ($allCerts.Length -eq 0) {
-            Write-LogWarn "No Certs found in certs file, check that $env:RANCHER_CERT exists and that the correct certificate is configured at $( $env:CATTLE_SERVER )/cacerts."
+        if (-Not (Test-Path $env:RANCHER_CERT)) {
+            Write-LogWarn "Certificate file not found at $env:RANCHER_CERT. Check that CATTLE_CA_CHECKSUM is correct and $($env:CATTLE_SERVER)/cacerts is reachable."
             return
         }
 
-        if ($allCerts.Length -eq 1) {
-            Write-LogInfo "Detected single certificate"
-            Import-Certificate -FilePath $env:RANCHER_CERT -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+        $certBlocks = [regex]::Matches(
+            (Get-Content $env:RANCHER_CERT -Raw),
+            '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----'
+        )
+
+        if ($certBlocks.Count -eq 0) {
+            Write-LogWarn "No valid certificate blocks found in $env:RANCHER_CERT. Check that the correct certificate is configured at $($env:CATTLE_SERVER)/cacerts."
             return
         }
 
-        # Import-Certificate does not automatically handle chains included in a single file,
-        # so we need to manually extract and import each certificate into the Root store.
-        Write-LogInfo "Detected certificate chain"
+        Write-LogInfo "Found $($certBlocks.Count) certificate(s) in $env:RANCHER_CERT"
 
-        $collection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        ForEach($cert in $allCerts) {
-            Write-LogInfo "Adding a certificate entry from the provided chain to the collection..."
-            $x5092 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new([System.Text.Encoding]::UTF8.GetBytes($cert))
-            $collection.Add($x5092)
-        }
-
-        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new([System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
+        $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+            [System.Security.Cryptography.X509Certificates.StoreName]::Root, "LocalMachine")
         $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::MaxAllowed)
-        Write-LogInfo "Adding collection to certificate store"
-        $certStore.AddRange($collection)
-        $certStore.Close()
+
+        try {
+            $imported = 0
+            foreach ($block in $certBlocks) {
+                $x509 = $null
+                try {
+                    $x509 = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                        [System.Text.Encoding]::UTF8.GetBytes($block.Value))
+                    Write-LogInfo "Importing certificate: ThumbPrint='$($x509.Thumbprint)'"
+                    $certStore.Add($x509)
+                    $imported++
+                }
+                catch {
+                    Write-LogWarn "Failed to import a certificate block. Error: $($_.Exception.Message)"
+                } finally {
+                    if ($null -ne $x509) {
+                        $x509.Dispose()
+                    }
+                }
+            }
+
+            if ($imported -eq 0) {
+                Write-LogWarn "No certificates were successfully imported from $env:RANCHER_CERT"
+            }
+            else {
+                Write-LogInfo "Successfully imported $imported of $($certBlocks.Count) certificate(s) into the Root store"
+            }
+        }
+        finally {
+            $certStore.Close()
+        }
     }
 
     function Test-RancherConnection {
@@ -592,7 +611,49 @@ csi-proxy:
         Add-Content -Path $env:CATTLE_AGENT_CONFIG_DIR/config -Value $proxyConfig
     }
 
-    function Stop-Agent() { 
+    function Start-Agent() {
+        [CmdletBinding()]
+        param (
+            [Parameter()]
+            [string]
+            $ServiceName
+        )
+        if (-Not (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
+            Write-LogInfo "$ServiceName service not found, registering now."
+            Push-Location c:\usr\local\bin
+            try {
+                if ($env:CATTLE_ENABLE_WINS_DELAYED_START -eq "true") {
+                    wins.exe srv app run --register --delayed-start
+                } else {
+                    wins.exe srv app run --register
+                }
+            } catch {
+                Write-LogFatal "Failed to execute wins.exe: $($_.Exception.Message)"
+            }
+            Pop-Location
+            Start-Sleep -s 5
+        }
+
+        Write-LogInfo "Starting $ServiceName service."
+        try {
+            Start-Service -Name $ServiceName
+        } catch {
+            Write-LogFatal "$ServiceName failed to start: $($_.Exception.Message)"
+        }
+
+        $timeout = 120
+        $elapsed = 0
+        while ((Get-Service $ServiceName).Status -ne 'Running') {
+            if ($elapsed -ge $timeout) {
+                Write-LogFatal "$ServiceName did not reach 'Running' state within $timeout seconds."
+            }
+            Write-LogInfo "Waiting for $ServiceName service to start (${elapsed}s elapsed)."
+            Start-Sleep -s 5
+            $elapsed += 5
+        }
+    }
+
+    function Stop-Agent() {
         [CmdletBinding()]
         param (
             [Parameter()]
@@ -816,35 +877,7 @@ csi-proxy:
             }
         }
                 
-        try {
-            Write-LogInfo "Checking if $serviceName service exists."
-            Get-Service -Name $serviceName
-        }
-        catch {
-            Write-LogInfo "$serviceName service not found, enabling agent service."
-            Push-Location c:\usr\local\bin
-            if ($env:CATTLE_ENABLE_WINS_DELAYED_START -eq "true") {
-                wins.exe srv app run --register --delayed-start
-            } else {
-                wins.exe srv app run --register
-            }
-            Pop-Location
-            Start-Sleep -s 5
-        }
-
-        try
-        {
-            Write-LogInfo "Starting $serviceName service."
-            Start-Service -Name $serviceName
-        } catch {
-            Write-LogInfo "$serviceName failed to start. Check the $serviceName logs for more information"
-            Write-LogInfo "Command: Get-WinEvent -ProviderName $serviceName | select-object TimeCreated,Message | Format-Table -wrap"
-            exit 1
-        }
-        while ((Get-Service $serviceName).Status -ne 'Running') {
-            Write-LogInfo "Waiting for $serviceName service to start."
-            Start-Sleep -s 5
-        }
+        Start-Agent -ServiceName $serviceName
     }
 
     Confirm-WindowsFeatures -RequiredFeatures @("Containers")

--- a/tests/integration/install_certs_test.ps1
+++ b/tests/integration/install_certs_test.ps1
@@ -111,35 +111,122 @@ Describe "Install script certificate tests" {
         Log-Info "Properly imported $expectedCertificates certificates"
     }
 
+    It "Imports certs from a file with extra blank lines between blocks" {
+        Log-Info "TEST: [Imports certs from a file with extra blank lines between blocks]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-ExtraNewlines $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that certs have been properly imported..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports certs from a file that contains a non-certificate PEM entry" {
+        Log-Info "TEST: [Imports certs from a file that contains a non-certificate PEM entry]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-FakePemEntry $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that certs have been properly imported..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports valid certs from a file that contains a corrupted certificate block" {
+        Log-Info "TEST: [Imports valid certs from a file that contains a corrupted certificate block]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Add-CorruptCertBlock $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that valid certs were still imported despite the corrupted block..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports certs from a chain carrying PKCS#12 bundle metadata between blocks" {
+        Log-Info "TEST: [Imports certs from a chain carrying PKCS#12 bundle metadata between blocks]"
+        $certData = Setup-CertFiles -length 3
+        $mutated  = Add-PKCSBundleMetadata $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming that all certs were imported despite the interleaved bag/subject/issuer metadata..."
+        check-thumbprints -shouldExist $true -thumbs $certData.ThumbPrints
+    }
+
+    It "Imports valid certs from a file with a truncated final block" {
+        Log-Info "TEST: [Imports valid certs from a file with a truncated final block]"
+        $certData = Setup-CertFiles -length 2
+        $mutated  = Remove-LastCertEnd $certData.FinalCertBlocks
+        $checkSum = Get-StringChecksum $mutated
+
+        check-thumbprints -shouldExist $false -thumbs $certData.ThumbPrints
+        Add-Content -Path install-certs-test.ps1 -Value "`$env:CATTLE_CA_CHECKSUM = `"$checkSum`""
+        Add-Content -Path install-certs-test.ps1 -Value "Invoke-WinsInstaller"
+
+        invoke-installScript -CertBlocks $mutated
+
+        Log-Info "Confirming import results: root cert should be imported, truncated leaf cert should not"
+        check-thumbprints -shouldExist $true  -thumbs @($certData.ThumbPrints[0])
+        check-thumbprints -shouldExist $false -thumbs @($certData.ThumbPrints[1])
+    }
+
     # utility functions only useful for this set of tests
     BeforeAll {
         function invoke-installScript() {
             param (
                 [Parameter()]
                 [String]
-                $certs
+                $CertBlocks = $certData.FinalCertBlocks
             )
 
             Log-Info "Starting mock Rancher API"
-            $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $certData.FinalCertBlocks
-            Start-Sleep 1
-            if ($job.State -ne "Running") {
-                # display job output to help debug job failure
-                Log-Error "Mock Rancher server failed to start"
-                $job | Receive-Job
-                $job.State | Should -Be -ExpectedValue "Running"
+            $job = Start-Job -ScriptBlock $StartMockRancherHandler -ArgumentList $CertBlocks
+            try {
+                Start-Sleep 1
+                if ($job.State -ne "Running") {
+                    # display job output to help debug job failure
+                    Log-Error "Mock Rancher server failed to start"
+                    $job | Receive-Job
+                    $job.State | Should -Be -ExpectedValue "Running"
+                }
+
+                Log-Info "Invoking install script"
+                .\install-certs-test.ps1
+                $installScriptExitCode = $LASTEXITCODE
+
+                Log-Info "Install script exited with code $installScriptExitCode"
+                $installScriptExitCode | Should -Be -ExpectedValue 0
             }
-
-            Log-Info "Invoking install script"
-            .\install-certs-test.ps1
-            $installScriptExitCode = $LASTEXITCODE
-
-            Log-Info "Stopping mock server"
-            curl.exe -sS http://localhost:8080/kill
-            Remove-Job -Id $job.Id -Force
-
-            Log-Info "Install script exited with code $installScriptExitCode"
-            $installScriptExitCode | Should -Be -ExpectedValue 0
+            finally {
+                # Always tear down the mock server, even if it never came up or an
+                # assertion above threw, so a single failure can't leak port 8080
+                # and cascade into every other test in this file.
+                Log-Info "Stopping mock server"
+                curl.exe -sS --max-time 5 http://localhost:8080/kill 2>&1 | Out-Null
+                Remove-Job -Id $job.Id -Force -ErrorAction SilentlyContinue
+            }
         }
 
         function check-thumbprints() {

--- a/tests/integration/utils.psm1
+++ b/tests/integration/utils.psm1
@@ -479,6 +479,78 @@ function newCert() {
     return $null
 }
 
+function Add-ExtraNewlines {
+    param([string]$CertData)
+    return $CertData -replace '-----END CERTIFICATE-----', "-----END CERTIFICATE-----`n`n"
+}
+
+function Add-FakePemEntry {
+    param([string]$CertData, [string]$EntryType = "PRIVATE KEY")
+    $fake = "-----BEGIN $EntryType-----`nZmFrZWRhdGE=`n-----END $EntryType-----"
+    return $fake + "`n" + $CertData
+}
+
+# Unlike Add-FakePemEntry, this wraps garbage base64 in a genuine
+# CERTIFICATE marker so it passes the regex match in Import-Certificates
+# but fails to parse as an X509Certificate2, exercising the per-block catch.
+function Add-CorruptCertBlock {
+    param([string]$CertData)
+    $corrupt = "-----BEGIN CERTIFICATE-----`nVGhpcyBpcyBub3QgYSB2YWxpZCBjZXJ0aWZpY2F0ZQ==`n-----END CERTIFICATE-----"
+    return $corrupt + "`n" + $CertData
+}
+
+# Removes the last END CERTIFICATE marker, leaving the final block truncated
+function Remove-LastCertEnd {
+    param([string]$CertData)
+    $idx = $CertData.LastIndexOf("-----END CERTIFICATE-----")
+    if ($idx -ge 0) { return $CertData.Substring(0, $idx) }
+    return $CertData
+}
+
+# Add-PKCSBundleMetadata rebuilds the chain so that each certificate block is
+# preceded by the human-readable metadata that
+# `openssl pkcs12 -in bundle.pfx -nokeys -out chain.pem` emits when a PKCS#12
+# bundle is extracted into a plain cacert chain. openssl writes a "Bag
+# Attributes" section plus subject=/issuer= lines ahead of every block, which
+# places errant metadata both before the first cert and between every
+# subsequent block.
+function Add-PKCSBundleMetadata {
+    param([string]$CertData)
+
+    $blocks = [regex]::Matches($CertData, '-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----')
+    $sb = [System.Text.StringBuilder]::new()
+    for ($j = 0; $j -lt $blocks.Count; $j++) {
+        if ($j -eq 0) {
+            $meta = @"
+Bag Attributes
+    localKeyID: 01 A2 B3 C4 D5 E6 F7 08 19 2A 3B 4C 5D 6E 7F 80
+    friendlyName: rancher
+subject=CN = wins-test-leaf-cert
+issuer=CN = wins-test-intermediate-cert
+"@
+        } else {
+            $meta = @"
+Bag Attributes: <No Attributes>
+subject=CN = wins-test-ca-cert
+issuer=CN = wins-test-root-CA
+"@
+        }
+        [void]$sb.AppendLine($meta)
+        [void]$sb.AppendLine($blocks[$j].Value)
+    }
+    return $sb.ToString()
+}
+
+# Hashes an in-memory string the same way Test-CaCheckSum hashes the downloaded file
+function Get-StringChecksum {
+    param([string]$Data)
+    $tmp = New-TemporaryFile
+    Set-Content -NoNewline -Path $tmp.FullName -Value $Data
+    $hash = (Get-FileHash -Path $tmp.FullName -Algorithm SHA256).Hash.ToLower()
+    Remove-Item $tmp.FullName -Force
+    return $hash
+}
+
 Export-ModuleMember -Function Setup-CertFiles
 Export-ModuleMember -Function Cleanup-CertFile
 Export-ModuleMember -Function Log-Info
@@ -498,3 +570,9 @@ Export-ModuleMember -Function Get-Permissions
 Export-ModuleMember -Function Test-Permissions
 Export-ModuleMember -Function Ensure-DependencyExistsForService
 Export-ModuleMember -Function Get-LatestCommitOrTag
+Export-ModuleMember -Function Add-ExtraNewlines
+Export-ModuleMember -Function Add-FakePemEntry
+Export-ModuleMember -Function Add-CorruptCertBlock
+Export-ModuleMember -Function Remove-LastCertEnd
+Export-ModuleMember -Function Add-PKCSBundleMetadata
+Export-ModuleMember -Function Get-StringChecksum


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56383

This is a backport of https://github.com/rancher/wins/pull/394 for 2.14. There were a few merge conflicts that I had to resolve, so some logic was dropped from `install.ps1` to only include the core fix for certificate chains 