### PR TITLE
[main] updated download location of uninstall script and made it remove itself at the end

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -80,6 +80,7 @@ Set-StrictMode -Version Latest
 $FALLBACK = "v0.5.5"
 $FALLBACK_BINARY_SUM = "cb42373cad3260d3b628de3d18cad13c0825577337499e4b9a05dc8926300512"
 $FALLBACK_UNINSTALL_SUM  = "bcc0f990176079f7dc69e668907230ac785d4676e037eef5b70cf3316e614adc"
+$RANCHER_SCRIPTS_PATH = "C:/rancher-scripts"
 
 function Invoke-WinsInstaller {
     [CmdletBinding()]
@@ -457,7 +458,7 @@ function Invoke-WinsInstaller {
     function Invoke-WinsUninstallScriptDownload {
         Invoke-RancherFileDownload `
             -Name            "uninstall script" `
-            -DestinationPath "$env:CATTLE_AGENT_BIN_PREFIX/bin/wins-agent-uninstall.ps1" `
+            -DestinationPath "$RANCHER_SCRIPTS_PATH/wins-agent-uninstall.ps1" `
             -Source          $env:UNINSTALL_SOURCE `
             -Url             $env:CATTLE_AGENT_UNINSTALL_URL `
             -LocalPath       $env:CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION `

--- a/tests/integration/uninstall_test.ps1
+++ b/tests/integration/uninstall_test.ps1
@@ -154,6 +154,7 @@ Describe "uninstall" {
         Remove-Item -Path "C:/tmp/test-wins-config"    -Recurse -Force -ErrorAction Ignore
         Remove-Item -Path "C:/tmp/test-wins-var"       -Recurse -Force -ErrorAction Ignore
         Remove-Item -Path "uninstaller-test.ps1"       -Force          -ErrorAction Ignore
+        Remove-Item -Path "C:/rancher-scripts"         -Recurse -Force -ErrorAction Ignore
 
         Remove-Item Env:\CATTLE_AGENT_LOGLEVEL -ErrorAction Ignore
     }
@@ -344,6 +345,61 @@ Describe "uninstall" {
 
         Remove-Item "C:/etc/windows-exporter" -Recurse -Force -ErrorAction Ignore
         Remove-Item "C:/etc/wmi-exporter"     -Recurse -Force -ErrorAction Ignore
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+    }
+
+    # -------------------------------------------------------------------------
+    # Uninstall script and rancher-scripts directory cleanup
+    # -------------------------------------------------------------------------
+
+    It "removes the uninstall script from C:/rancher-scripts after uninstall" {
+        Log-Info "TEST: [removes the uninstall script from C:/rancher-scripts after uninstall]"
+
+        New-Item -Path "C:/rancher-scripts" -ItemType Directory -Force | Out-Null
+        New-Item -Path "C:/rancher-scripts/wins-agent-uninstall.ps1" -ItemType File -Force | Out-Null
+
+        Test-Path "C:/rancher-scripts/wins-agent-uninstall.ps1" | Should -Be $true
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/rancher-scripts/wins-agent-uninstall.ps1" | Should -Be $false
+    }
+
+    It "removes C:/rancher-scripts when it is left empty after uninstall" {
+        Log-Info "TEST: [removes C:/rancher-scripts when it is left empty after uninstall]"
+
+        New-Item -Path "C:/rancher-scripts" -ItemType Directory -Force | Out-Null
+        New-Item -Path "C:/rancher-scripts/wins-agent-uninstall.ps1" -ItemType File -Force | Out-Null
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/rancher-scripts" | Should -Be $false
+    }
+
+    It "keeps C:/rancher-scripts when other files remain after uninstall" {
+        Log-Info "TEST: [keeps C:/rancher-scripts when other files remain after uninstall]"
+
+        New-Item -Path "C:/rancher-scripts" -ItemType Directory -Force | Out-Null
+        New-Item -Path "C:/rancher-scripts/wins-agent-uninstall.ps1" -ItemType File -Force | Out-Null
+        New-Item -Path "C:/rancher-scripts/other-file.txt" -ItemType File -Force | Out-Null
+
+        $succeeded = Invoke-Uninstaller
+
+        $succeeded | Should -Be $true
+        Test-Path "C:/rancher-scripts" | Should -Be $true
+        Test-Path "C:/rancher-scripts/wins-agent-uninstall.ps1" | Should -Be $false
+        Test-Path "C:/rancher-scripts/other-file.txt" | Should -Be $true
+    }
+
+    It "does not fail when C:/rancher-scripts does not exist" {
+        Log-Info "TEST: [does not fail when C:/rancher-scripts does not exist]"
+
+        Remove-Item -Path "C:/rancher-scripts" -Recurse -Force -ErrorAction Ignore
 
         $succeeded = Invoke-Uninstaller
 

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -19,6 +19,8 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+$RANCHER_SCRIPTS_PATH = "C:/rancher-scripts"
+
 function Invoke-WinsUninstaller {
     [CmdletBinding()]
     param ()
@@ -136,8 +138,8 @@ function Invoke-WinsUninstaller {
             Write-LogInfo "Checking if $ProcessName process exists"
             if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
                 Write-LogInfo "$ProcessName process found, stopping now"
-                Stop-Process -Name $ProcessName
-                while (-Not (Get-Process -Name $ProcessName).HasExited) {
+                Stop-Process -Name $ProcessName -Force -Confirm:$false
+                while (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
                     Write-LogInfo "Waiting for $ProcessName process to stop"
                     Start-Sleep -s 5
                 }
@@ -168,6 +170,30 @@ function Invoke-WinsUninstaller {
         }
     }
 
+    function Remove-UninstallScript() {
+        $rancherScriptsPath = $RANCHER_SCRIPTS_PATH
+        $uninstallScriptPath = "$rancherScriptsPath/wins-agent-uninstall.ps1"
+        if (Test-Path $uninstallScriptPath) {
+            Write-LogInfo "Removing uninstall script at $uninstallScriptPath"
+            try {
+                Remove-Item -Path $uninstallScriptPath -Force
+            }
+            catch {
+                Write-LogWarn "Failed to remove uninstall script at $uninstallScriptPath : $_"
+            }
+        }
+
+        if ((Test-Path $rancherScriptsPath) -and (-Not (Get-ChildItem -Path $rancherScriptsPath -Force))) {
+            Write-LogInfo "$rancherScriptsPath is empty, removing it"
+            try {
+                Remove-Item -Path $rancherScriptsPath -Force
+            }
+            catch {
+                Write-LogWarn "Failed to remove $rancherScriptsPath : $_"
+            }
+        }
+    }
+
     function Invoke-WinsAgentUninstall() {
         $serviceName = "rancher-wins"
         $csiProxyServiceName = "csiproxy"
@@ -183,6 +209,7 @@ function Invoke-WinsUninstaller {
         Remove-WinsConfig
         Remove-Service -ServiceName $csiProxyServiceName
         Remove-Service -ServiceName $serviceName
+        Remove-UninstallScript
     }
 
     Invoke-WinsAgentUninstall


### PR DESCRIPTION
### Summary
<!-- Add a link to a tracking GitHub issue, typically located in rancher/rancher -->
Issue: https://github.com/rancher/rancher/issues/51850


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Adds cleanup of the wins uninstall script (and its containing directory) at the end of the uninstall process, and fixes a process-stop race condition.
The wins-agent-uninstall.ps1 script was being removed by rke2-uninstall.ps1 during uninstall since rke2-uninstall script removes the whole c:/usr directory so place the uninstall script in a constant c:\rancher-scripts path

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
install.ps1
- Added $RANCHER_SCRIPTS_PATH constant (C:/rancher-scripts) for the uninstall script location.
uninstall.ps1
Added Remove-UninstallScript function that:
- Removes wins-agent-uninstall.ps1 if present.
- Removes the C:/rancher-scripts directory if it's left empty.
- Added Remove-UninstallScript into Invoke-WinsAgentUninstall, called after service removal.
- uses Stop-Process -Force -Confirm:$false and checks Get-Process -ErrorAction SilentlyContinue in the wait loop instead of .HasExited, avoiding a potential error when the process handle is already gone.
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->